### PR TITLE
MultiJson dependency uses ~> but should be >=

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ Echoe.new('jwt', '0.1.5') do |p|
   p.author         = "Jeff Lindsay"
   p.email          = "jeff.lindsay@twilio.com"
   p.ignore_pattern = ["tmp/*"]
-  p.runtime_dependencies = ["multi_json >=1.3.0"]
+  p.runtime_dependencies = ["multi_json >=1.0"]
   p.development_dependencies = ["echoe >=4.6.3"]
 end
 


### PR DESCRIPTION
The dependency was copied off the `oauth2` gem, but that's going to interfere with a lot of other gems that use more recent versions. The interface is stable, modulo a few warnings, so `>=` is a better choice.
