### PR TITLE
Fixes a theoretical timing attack

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -79,7 +79,7 @@ module JWT
 
       begin
         if ["HS256", "HS384", "HS512"].include?(algo)
-          raise JWT::DecodeError.new("Signature verification failed") unless signature == sign_hmac(algo, signing_input, key)
+          raise JWT::DecodeError.new("Signature verification failed") unless secure_compare(signature, sign_hmac(algo, signing_input, key))
         elsif ["RS256", "RS384", "RS512"].include?(algo)
           raise JWT::DecodeError.new("Signature verification failed") unless verify_rsa(algo, key, signing_input, signature)
         else
@@ -90,6 +90,17 @@ module JWT
       end
     end
     payload
+  end
+
+  # From devise
+  # constant-time comparison algorithm to prevent timing attacks
+  def self.secure_compare(a, b)
+    return false if a.nil? || b.nil? || a.empty? || b.empty? || a.bytesize != b.bytesize
+    l = a.unpack "C#{a.bytesize}"
+
+    res = 0
+    b.each_byte { |byte| res |= byte ^ l.shift }
+    res == 0
   end
 
 end


### PR DESCRIPTION
Fixes a theoretical timing attack:

Based on devise secure_compare:
https://github.com/plataformatec/devise/blob/master/lib/devise.rb#L447

More info:
http://rdist.root.org/2010/01/07/timing-independent-array-comparison/
