### PR TITLE
Catch MultiJson::LoadError and reraise as JWT::DecodeError

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -67,7 +67,7 @@ module JWT
       header = MultiJson.decode(base64url_decode(header_segment))
       payload = MultiJson.decode(base64url_decode(payload_segment))
       signature = base64url_decode(crypto_segment) if verify
-    rescue JSON::ParserError
+    rescue MultiJson::LoadError => e
       raise JWT::DecodeError.new("Invalid segment encoding")
     end
     if verify == true

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -37,6 +37,13 @@ describe JWT do
     decoded_payload.should == example_payload
   end
 
+  it "raises exception when the token is invalid" do
+    example_secret = 'secret'
+    # Same as above exmaple with some random bytes replaced
+    example_jwt = 'eyJhbGciOiAiSFMyNTYiLCAidHiMomlwIjogIkJ9.eyJoZWxsbyI6ICJ3b3JsZCJ9.tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8'
+    lambda { JWT.decode(example_jwt, example_secret) }.should raise_error(JWT::DecodeError)
+  end
+
   it "raises exception with wrong hmac key" do
     right_secret = 'foo'
     bad_secret = 'bar'


### PR DESCRIPTION
This returns the JWT.decode method signature to what it was previously
by capturing MultiJson errors and re-raising as JWT::DecodeError
