### PR TITLE
Verify if verify is truthy (not just true)

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -70,7 +70,7 @@ module JWT
     rescue MultiJson::LoadError => e
       raise JWT::DecodeError.new("Invalid segment encoding")
     end
-    if verify == true
+    if verify
       algo = header['alg']
 
       if keyfinder

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -66,6 +66,14 @@ describe JWT do
     decoded_payload.should == @payload
   end
 
+  it "checks the key when verify is truthy" do
+    right_secret = 'foo'
+    bad_secret = 'bar'
+    jwt = JWT.encode(@payload, right_secret)
+    verify = "yes" =~ /^y/i
+    lambda { JWT.decode(jwt, bad_secret, verify) }.should raise_error(JWT::DecodeError)
+  end
+
   it "raises exception on unsupported crypto algorithm" do
     lambda { JWT.encode(@payload, "secret", 'HS1024') }.should raise_error(NotImplementedError)
   end


### PR DESCRIPTION
Previously, verification was carried out only if `verify == true`, rather than any non-`false`, non-`nil` value, as is conventional in Ruby.

This made it perilously easy to skip verification by accident.
