### PR TITLE
Don't leave errors in OpenSSL.errors when there is a decoding error.

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -87,6 +87,8 @@ module JWT
         end
       rescue OpenSSL::PKey::PKeyError
         raise JWT::DecodeError.new("Signature verification failed")
+      ensure
+        OpenSSL.errors.clear
       end
     end
     payload

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -115,6 +115,11 @@ describe JWT do
     end
   end
 
+  # no method should leave OpenSSL.errors populated
+  after do
+    OpenSSL.errors.should be_empty
+  end
+
   it "raise exception on invalid signature" do
     pubkey = OpenSSL::PKey::RSA.new(<<-PUBKEY)
 -----BEGIN PUBLIC KEY-----


### PR DESCRIPTION
Leaving errors in OpenSSL.errors was causing subsequent ssl operations to fail.
