### PR TITLE
Echoe doesn't define a license= method

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ Echoe.new('jwt', '0.1.8') do |p|
   p.ignore_pattern = ["tmp/*"]
   p.runtime_dependencies = ["multi_json >=1.5"]
   p.development_dependencies = ["echoe >=4.6.3"]
-  p.license        = "MIT"
+  p.licenses       = "MIT"
 end
 
 task :test do


### PR DESCRIPTION
Fixes bug introduced by @nycvotes-dev in c9504c7ad03171af3b0b93e57abc67859b751d3f.
