### PR TITLE
fixed urlsafe base64 encoding

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -41,7 +41,7 @@ module JWT
   end
 
   def base64url_encode(str)
-    Base64.encode64(str).tr("-_", "+/").gsub(/[\n=]/, "")
+    Base64.encode64(str).tr("+/", "-_").gsub(/[\n=]/, "")
   end
 
   def encode(payload, key, algorithm="HS256", header_fields={})

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -159,4 +159,11 @@ PUBKEY
     )
     lambda { JWT.decode(jwt, pubkey, true) }.should raise_error(JWT::DecodeError)
   end
+
+  describe "urlsafe base64 encoding" do
+    it "replaces + and / with - and _" do
+      Base64.stub(:encode64) { "string+with/non+url-safe/characters_" }
+      JWT.base64url_encode("foo").should == "string-with_non-url-safe_characters_"
+    end
+  end
 end


### PR DESCRIPTION
This pull request should fix the url safe base64 encoding. I have noticed that `+` and `/` signs are not being replaced since following refactoring: https://github.com/progrium/ruby-jwt/commit/881e307cfd976642f9468c33bcd0ef3ff5a06c6f

The condition was the wrong way around.

/cc @threedaymonk @ollyjshaw
