### PR TITLE
Make MultiJson optional for Ruby 1.9+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem 'json', '>= 1.2.4'
-gem 'multi_json', '~> 1.0'
+gem 'multi_json', '~> 1.0', :platforms => :ruby_18
 gem 'jruby-openssl', :platforms => :jruby
 
 gem 'rubysl', '~> 2.0', :platforms => :rbx

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,6 @@ Echoe.new('jwt', '0.1.11') do |p|
   p.author         = "Jeff Lindsay"
   p.email          = "progrium@gmail.com"
   p.ignore_pattern = ["tmp/*"]
-  p.runtime_dependencies = ["multi_json >=1.5"]
   p.development_dependencies = ["echoe >=4.6.3"]
   p.licenses       = "MIT"
 end

--- a/lib/jwt/json.rb
+++ b/lib/jwt/json.rb
@@ -1,16 +1,30 @@
 module JWT
   module Json
+    if RUBY_VERSION >= "1.9" && !defined?(MultiJson)
+      require 'json'
 
-    require "multi_json"
+      def decode_json(encoded)
+        JSON.parse(encoded)
+      rescue JSON::ParserError
+        raise JWT::DecodeError.new("Invalid segment encoding")
+      end
 
-    def decode_json(encoded)
-      MultiJson.decode(encoded)
-    rescue MultiJson::LoadError
-      raise JWT::DecodeError.new("Invalid segment encoding")
-    end
+      def encode_json(raw)
+        JSON.generate(raw)
+      end
 
-    def encode_json(raw)
-      MultiJson.encode(raw)
+    else
+      require "multi_json"
+
+      def decode_json(encoded)
+        MultiJson.decode(encoded)
+      rescue MultiJson::LoadError
+        raise JWT::DecodeError.new("Invalid segment encoding")
+      end
+
+      def encode_json(raw)
+        MultiJson.encode(raw)
+      end
     end
   end
 end


### PR DESCRIPTION
MultiJson is being EOL'd and major libraries (Rails, uglifier, etc.) have started phasing out their dependency - https://github.com/rails/rails/pull/10576 .  This PR accommodates this trend, by making MultiJson an optional dependency for Ruby 1.9+.

Users of the jwt gem can still use MultiJson even when using Ruby 1.9+ by simply calling `require 'multi_json'` before they require the gem.
