### PR TITLE
Remove unused variable in the sample code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,6 @@ From [Oauth JSON Web Token 4.1.7. "jti" (JWT ID) Claim](https://tools.ietf.org/h
 > The `jti` (JWT ID) claim provides a unique identifier for the JWT. The identifier value MUST be assigned in a manner that ensures that there is a negligible probability that the same value will be accidentally assigned to a different data object; if the application uses multiple issuers, collisions MUST be prevented among values produced by different issuers as well. The `jti` claim can be used to prevent the JWT from being replayed. The `jti` value is a case-sensitive string. Use of this claim is OPTIONAL.
 
 ```ruby
-user_id = 'email@address.tld'
 # in order to use JTI you have to add iat
 iat = Time.now.to_i
 # Use the secret and iat to create a unique key per request to prevent replay attacks


### PR DESCRIPTION
I found an unused variable in the sample code at README file. `user_id` was removed at this commit https://github.com/jwt/ruby-jwt/commit/f2fe2ac55cac849e6b45d27a91604b4e4b96c8cf#diff-04c6e90faac2675aa89e2176d2eec7d8L265 from `jti_raw` but was forgotten to remove the original variable I guess.