### PR TITLE
Include LICENSE and README.md in gem

### DIFF
--- a/Manifest
+++ b/Manifest
@@ -1,4 +1,6 @@
 Rakefile
+README.md
+LICENSE
 lib/jwt.rb
 lib/jwt/json.rb
 spec/helper.rb


### PR DESCRIPTION
Technically, the LICENSE is supposed to be distributed with the code. Adding the README is just a convenience.