### PR TITLE
Fix incorrect `iat` examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ token = JWT.encode jti_payload, hmac_secret, 'HS256'
 
 begin
   # Add jti and iat to the validation to check if the token has been manipulated
-  decoded_token = JWT.decode token, hmac_secret, true, { 'iat' => iat, 'jti' => jti, :verify_jti => true, :algorithm => 'HS256' }
+  decoded_token = JWT.decode token, hmac_secret, true, { 'jti' => jti, :verify_jti => true, :algorithm => 'HS256' }
   # Check if the JTI has already been used
 rescue JWT::InvalidJtiError
   # Handle invalid token, e.g. logout user or deny access

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -132,7 +132,7 @@ describe JWT do
   end
 
   it 'raises decode exception when iat is invalid' do
-    # example_payload = {'hello' => 'world', 'iat' => 'abc'}
+    # example_payload = {'hello' => 'world', 'iat' => '1425917209'}
     example_secret = 'secret'
     example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoiMTQyNTkxNzIwOSJ9.Mn_vk61xWjIhbXFqAB0nFmNkDiCmfzUgl_LaCKRT6S8'
     expect { JWT.decode(example_jwt, example_secret, true, verify_iat: true) }.to raise_error(JWT::InvalidIatError)

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -127,7 +127,7 @@ describe JWT do
     example_payload = { 'hello' => 'world', 'iat' => 1_425_917_209 }
     example_secret = 'secret'
     example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNDI1OTE3MjA5fQ.m4F-Ugo7aLnLunBBO3BeDidyWMx8T9eoJz6FW2rgQhU'
-    decoded_payload = JWT.decode(example_jwt, example_secret, true, iat: true)
+    decoded_payload = JWT.decode(example_jwt, example_secret, true)
     expect(decoded_payload).to include(example_payload)
   end
 
@@ -135,7 +135,7 @@ describe JWT do
     # example_payload = {'hello' => 'world', 'iat' => 'abc'}
     example_secret = 'secret'
     example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoiMTQyNTkxNzIwOSJ9.Mn_vk61xWjIhbXFqAB0nFmNkDiCmfzUgl_LaCKRT6S8'
-    expect { JWT.decode(example_jwt, example_secret, true, verify_iat: true, 'iat' => 1_425_917_209) }.to raise_error(JWT::InvalidIatError)
+    expect { JWT.decode(example_jwt, example_secret, true, verify_iat: true) }.to raise_error(JWT::InvalidIatError)
   end
 
   it 'raises decode exception when iat is in the future' do


### PR DESCRIPTION
In the JWT ID Claim example in README.md the `iat` is passed in the options to `JWT.decode`. This confused me when reading the doc. The `iat` is not used in options to `JWT.decode`.

This PR removed `iat` from this example and also from the relevant specs.