### PR TITLE
add RSpec task to Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,11 @@
 require 'bundler/gem_tasks'
+
+begin
+  require 'rspec/core/rake_task'
+
+  RSpec::Core::RakeTask.new(:test)
+
+  task :default => :test
+rescue LoadError
+  # no rspec available
+end


### PR DESCRIPTION
`rake test` now runs the RSpec tests as advertised in the documentation.