### PR TITLE
Allow a proc to be passed for JTI verification

### DIFF
--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -37,7 +37,11 @@ module JWT
     end
 
     def self.verify_jti(payload, _options)
-      fail(JWT::InvalidJtiError, 'Missing jti') if payload['jti'].to_s == ''
+      if _options[:verify_jti].class == Proc
+        fail(JWT::InvalidJtiError, 'Invalid jti') unless _options[:verify_jti].call(payload['jti'])
+      else
+        fail(JWT::InvalidJtiError, 'Missing jti') if payload['jti'].to_s == ''
+      end
     end
 
     def self.verify_aud(payload, options)

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -377,6 +377,18 @@ describe JWT do
           JWT.decode token, data[:secret], true, verify_jti: true
         end.to_not raise_error
       end
+
+      it 'false proc should raise JWT::InvalidJtiError' do
+        expect do
+          JWT.decode token, data[:secret], true, verify_jti: lambda { |jti| false }
+        end.to raise_error JWT::InvalidJtiError
+      end
+
+      it 'true proc should not raise JWT::InvalidJtiError' do
+        expect do
+          JWT.decode invalid_token, data[:secret], true, verify_jti: lambda { |jti| true }
+        end.to_not raise_error
+      end
     end
   end
 


### PR DESCRIPTION
Since verifying a JTI isn't part of the JWT specification, I added the ability to pass a proc to JWT.decode to determine if a JTI is valid. I also updated the readme to explain how this works and to explain how the current method of validation works.

See #110 