### PR TITLE
Drop ruby 1.9.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.0


### PR DESCRIPTION
Drop ruby 1.9.3 - support ended on 2016-02-23. 
See: https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/