### PR TITLE
iat can be a float value

### DIFF
--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -43,7 +43,7 @@ module JWT
     def verify_iat
       return unless @payload.include?('iat')
 
-      if !(@payload['iat'].is_a?(Float)) || @payload['iat'].to_f > (Time.now.to_f + leeway)
+      if !(@payload['iat'].is_a?(Numeric)) || @payload['iat'].to_f > (Time.now.to_f + leeway)
         fail(JWT::InvalidIatError, 'Invalid iat')
       end
     end

--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -43,7 +43,7 @@ module JWT
     def verify_iat
       return unless @payload.include?('iat')
 
-      if !(@payload['iat'].is_a?(Integer)) || @payload['iat'].to_i > (Time.now.to_i + leeway)
+      if !(@payload['iat'].is_a?(Float)) || @payload['iat'].to_f > (Time.now.to_f + leeway)
         fail(JWT::InvalidIatError, 'Invalid iat')
       end
     end

--- a/spec/jwt/verify_spec.rb
+++ b/spec/jwt/verify_spec.rb
@@ -63,7 +63,7 @@ module JWT
     end
 
     context '.verify_iat(payload, options)' do
-      let(:iat) { Time.now.to_i }
+      let(:iat) { Time.now.to_f }
       let(:payload) { base_payload.merge('iat' => iat) }
 
       it 'must allow a valid iat' do

--- a/spec/jwt/verify_spec.rb
+++ b/spec/jwt/verify_spec.rb
@@ -74,7 +74,11 @@ module JWT
         Verify.verify_iat(payload.merge('iat' => (iat + 60)), options.merge(leeway: 70))
       end
 
-      it 'must raise JWT::InvalidIatError when the iat value is not an Integer' do
+      it 'must properly handle integer times' do
+        Verify.verify_iat(payload.merge('iat' => Time.now.to_i), options)
+      end
+
+      it 'must raise JWT::InvalidIatError when the iat value is not Numeric' do
         expect do
           Verify.verify_iat(payload.merge('iat' => 'not a number'), options)
         end.to raise_error JWT::InvalidIatError


### PR DESCRIPTION
1. The iat attribute can be a float or an integer. The [spec](https://tools.ietf.org/html/rfc7519#page-10) says:

> The "iat" (issued at) claim identifies the time at which the JWT was
   issued.  This claim can be used to determine the age of the JWT.  Its
   value MUST be a number containing a NumericDate value.  Use of this
   claim is OPTIONAL.

Where a NumericDate is defined as:

> NumericDate
      A JSON numeric value representing the number of seconds from
      1970-01-01T00:00:00Z UTC until the specified UTC date/time,
      ignoring leap seconds.  This is equivalent to the IEEE Std 1003.1,
      2013 Edition [POSIX.1] definition "Seconds Since the Epoch", in
      which each day is accounted for by exactly 86400 seconds, other
      than that non-integer values can be represented.  See RFC 3339
      [RFC3339] for details regarding date/times in general and UTC in
      particular.

which explicitly allows for non-integer values.

2. Is there anything else that needs doing for float iat to work? I couldn't find anything but I took a very shallow look.