### PR TITLE
Improve error message for exp claim in payload

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -73,6 +73,7 @@ module JWT
   end
 
   def encoded_payload(payload)
+    raise InvalidPayload, "exp claim must be an integer" if payload['exp'] && payload['exp'].is_a?(Time)
     base64url_encode(encode_json(payload))
   end
 

--- a/lib/jwt/error.rb
+++ b/lib/jwt/error.rb
@@ -9,4 +9,5 @@ module JWT
   class InvalidAudError < DecodeError; end
   class InvalidSubError < DecodeError; end
   class InvalidJtiError < DecodeError; end
+  class InvalidPayload < DecodeError; end
 end

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -50,6 +50,14 @@ describe JWT do
       expect(header['alg']).to eq alg
       expect(jwt_payload).to eq payload
     end
+
+    it 'should display a better error message if payload exp is_a?(Time)' do
+      payload['exp'] = Time.now
+
+      expect do
+        JWT.encode payload, nil, alg
+      end.to raise_error JWT::InvalidPayload
+    end
   end
 
   %w(HS256 HS384 HS512).each do |alg|


### PR DESCRIPTION
A better error message is displayed if a Time object is used for the exp
claim instead of an integer unix time stamp.

Fixes #148.