### PR TITLE
Pass payload to keyfinder

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -141,6 +141,7 @@ module JWT
   def signature_algorithm_and_key(header, payload, key, &keyfinder)
     if keyfinder
       key = (keyfinder.arity == 2) ? keyfinder.call(header, payload) : keyfinder.call(header)
+      raise JWT::DecodeError, 'No verification key available'  unless key
     end
     [header['alg'], key]
   end

--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -140,8 +140,12 @@ module JWT
 
   def signature_algorithm_and_key(header, payload, key, &keyfinder)
     if keyfinder
-      key = (keyfinder.arity == 2) ? keyfinder.call(header, payload) : keyfinder.call(header)
-      raise JWT::DecodeError, 'No verification key available'  unless key
+      key = if keyfinder.arity == 2
+        yield(header, payload)
+      else
+        yield(header)
+      end
+      raise JWT::DecodeError, 'No verification key available' unless key
     end
     [header['alg'], key]
   end


### PR DESCRIPTION
I have an app that I would like to authenticate to using tokens signed with HMAC (created by the app) or ECDSA (created by other companies), depending on the value of the issuer (`iss`) claim.  I'm using the `keyfinder` block to implement that logic, but it needs to have the `payload` passed to it in order to find the appropriate public key for the issuer.  To that end, I made a small change to pass both the `header` and `payload` to `keyfinder`, if it has arity of 2.  Now my calling code looks like:

```ruby
payload = JWT.decode(token, nil, true) do |header, payload|
  alg = header['alg']
  if alg.starts_with?('HS')
    # HMAC token
    Rails.application.secrets[:secret_key_base]

  elsif alg.starts_with?('ES') && (pub_key = Company.where(id: payload['iss']).pluck(:public_key).first)
    # ECDSA token
    OpenSSL::PKey::EC.new(pub_key)

  else
    nil
  end
end.first
```