### PR TITLE
Validate audience when payload is a scalar and options is an array

### DIFF
--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -20,23 +20,11 @@ module JWT
     def verify_aud
       return unless (options_aud = extract_option(:aud))
 
-      if @payload['aud'].is_a?(Array)
-        verify_aud_array(@payload['aud'], options_aud)
-      else
+      if ([*@payload['aud']] & [*options_aud]).empty?
         raise(
           JWT::InvalidAudError,
           "Invalid audience. Expected #{options_aud}, received #{@payload['aud'] || '<none>'}"
-        ) unless @payload['aud'].to_s == options_aud.to_s
-      end
-    end
-
-    def verify_aud_array(audience, options_aud)
-      if options_aud.is_a?(Array)
-        options_aud.each do |aud|
-          raise(JWT::InvalidAudError, 'Invalid audience') unless audience.include?(aud.to_s)
-        end
-      else
-        raise(JWT::InvalidAudError, 'Invalid audience') unless audience.include?(options_aud.to_s)
+        )
       end
     end
 

--- a/spec/jwt/verify_spec.rb
+++ b/spec/jwt/verify_spec.rb
@@ -8,7 +8,7 @@ module JWT
     let(:options) { { leeway: 0 } }
 
     context '.verify_aud(payload, options)' do
-      let(:scalar_aud) { 'ruby-jwt-audience' }
+      let(:scalar_aud) { 'ruby-jwt-aud' }
       let(:array_aud) { %w(ruby-jwt-aud test-aud ruby-ruby-ruby) }
       let(:scalar_payload) { base_payload.merge('aud' => scalar_aud) }
       let(:array_payload) { base_payload.merge('aud' => array_aud) }
@@ -45,6 +45,22 @@ module JWT
 
       it 'must allow an array with any value matching the one in the options with a string options key' do
         Verify.verify_aud(array_payload, options.merge('aud' => array_aud.first))
+      end
+
+      it 'must allow an array with any value matching any value in the options array' do
+        Verify.verify_aud(array_payload, options.merge(aud: array_aud))
+      end
+
+      it 'must allow an array with any value matching any value in the options array with a string options key' do
+        Verify.verify_aud(array_payload, options.merge("aud" => array_aud))
+      end
+
+      it 'must allow a singular audience payload matching any value in the options array' do
+        Verify.verify_aud(scalar_payload, options.merge(aud: array_aud))
+      end
+
+      it 'must allow a singular audience payload matching any value in the options array with a string options key' do
+        Verify.verify_aud(scalar_payload, options.merge("aud" => array_aud))
       end
 
       it 'should allow strings or symbols in options array' do


### PR DESCRIPTION
I recently updated from gem version 1.5.1 to 1.5.6 in one of my applications and I found that this behavior has changed. In my application, the JWT issuer creates the JWT with a scalar (string) `aud` claim.  The JWT consumer verifies the `aud` claim against an array of possible values. The consumer has multiple valid names and a valid JWT could target any of those names as an `aud`.  This works fine in v1.5.1, but the audience validation fails in v1.5.6.  I'm not sure if this change was intentional. Based on my reading of the RFC this particular case seems like an implementation detail.