### PR TITLE
Make algorithm option required to verify signature

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -107,9 +107,10 @@ module JWT
 
   def decode_verify_signature(key, header, payload, signature, signing_input, options, &keyfinder)
     algo, key = signature_algorithm_and_key(header, payload, key, &keyfinder)
-    if options[:algorithm] && algo != options[:algorithm]
-      raise JWT::IncorrectAlgorithm, 'Expected a different algorithm'
-    end
+
+    raise(JWT::IncorrectAlgorithm, 'An algorithm must be specified') unless options[:algorithm]
+    raise(JWT::IncorrectAlgorithm, 'Expected a different algorithm') unless algo == options[:algorithm]
+
     verify_signature(algo, key, signing_input, signature)
   end
 

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -69,7 +69,7 @@ describe JWT do
       end
 
       it 'should decode a valid token' do
-        jwt_payload, header = JWT.decode data[alg], data[:secret]
+        jwt_payload, header = JWT.decode data[alg], data[:secret], true, algorithm: alg
 
         expect(header['alg']).to eq alg
         expect(jwt_payload).to eq payload
@@ -77,7 +77,7 @@ describe JWT do
 
       it 'wrong secret should raise JWT::DecodeError' do
         expect do
-          JWT.decode data[alg], 'wrong_secret'
+          JWT.decode data[alg], 'wrong_secret', true, algorithm: alg
         end.to raise_error JWT::DecodeError
       end
 
@@ -98,7 +98,7 @@ describe JWT do
       end
 
       it 'should decode a valid token' do
-        jwt_payload, header = JWT.decode data[alg], data[:rsa_public]
+        jwt_payload, header = JWT.decode data[alg], data[:rsa_public], true, algorithm: alg
 
         expect(header['alg']).to eq alg
         expect(jwt_payload).to eq payload
@@ -108,7 +108,7 @@ describe JWT do
         key = OpenSSL::PKey.read File.read(File.join(CERT_PATH, 'rsa-2048-wrong-public.pem'))
 
         expect do
-          JWT.decode data[alg], key
+          JWT.decode data[alg], key, true, algorithm: alg
         end.to raise_error JWT::DecodeError
       end
 
@@ -131,14 +131,14 @@ describe JWT do
       let(:wrong_key) { OpenSSL::PKey.read(File.read(File.join(CERT_PATH, 'ec256-wrong-public.pem'))) }
 
       it 'should generate a valid token' do
-        jwt_payload, header = JWT.decode data[alg], data["#{alg}_public"]
+        jwt_payload, header = JWT.decode data[alg], data["#{alg}_public"], true, algorithm: alg
 
         expect(header['alg']).to eq alg
         expect(jwt_payload).to eq payload
       end
 
       it 'should decode a valid token' do
-        jwt_payload, header = JWT.decode data[alg], data["#{alg}_public"]
+        jwt_payload, header = JWT.decode data[alg], data["#{alg}_public"], true, algorithm: alg
 
         expect(header['alg']).to eq alg
         expect(jwt_payload).to eq payload
@@ -195,6 +195,14 @@ describe JWT do
           JWT.decode token, data[:secret], true, algorithm: 'HS512'
         end.not_to raise_error
       end
+
+      it 'should raise JWT::IncorrectAlgorithm if no algorithm is provided' do
+        token = JWT.encode payload, data[:rsa_public].to_s, 'HS256'
+
+        expect do
+          JWT.decode token, data[:rsa_public], true
+        end.to raise_error JWT::IncorrectAlgorithm
+      end
     end
 
     context 'issuer claim' do
@@ -208,7 +216,7 @@ describe JWT do
 
       it 'if verify_iss is set to false (default option) should not raise JWT::InvalidIssuerError' do
         expect do
-          JWT.decode token, data[:secret], true, iss: iss
+          JWT.decode token, data[:secret], true, iss: iss, algorithm: 'HS256'
         end.not_to raise_error
       end
     end


### PR DESCRIPTION
Looks like this was discussed before in https://github.com/jwt/ruby-jwt/issues/107, which was closed with a README update specifying the algorithm was required, but it doesn't seem like the code is actually requiring it.

If the algorithm is not provided and the one in the token's header is used
instead, we might be vulnerable to the attack explained here:

https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/

For ex:

A server expecting an RSA signed token would do this:

`JWT.decode(token, rsa_public)`

So an attacker can potentially sign a token with HS256 using the same RSA public
key (which is publicly available), and the server will think it's valid.

`JWT.encode({ user: 1 }, rsa_public, 'HS256')`

This doesn't seem to be exploitable right now because the current implementation
of OpenSSL::HMAC.digest expects a string as the key, so if rsa_public is an
OpenSSL::PKey::RSA object, JWT.decode will raise an error. But it would be
better not to depend on this OpenSSL::HMAC.digest behavior