### PR TITLE
Add options for claim-specific leeway

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ token = JWT.encode exp_payload, hmac_secret, 'HS256'
 
 begin
   # add leeway to ensure the token is still accepted
-  decoded_token = JWT.decode token, hmac_secret, true, { :leeway => leeway, :algorithm => 'HS256' }
+  decoded_token = JWT.decode token, hmac_secret, true, { :exp_leeway => leeway, :algorithm => 'HS256' }
 rescue JWT::ExpiredSignature
   # Handle expired token, e.g. logout user or deny access
 end
@@ -258,7 +258,7 @@ token = JWT.encode nbf_payload, hmac_secret, 'HS256'
 
 begin
   # add leeway to ensure the token is valid
-  decoded_token = JWT.decode token, hmac_secret, true, { :leeway => leeway, :algorithm => 'HS256' }
+  decoded_token = JWT.decode token, hmac_secret, true, { :nbf_leeway => leeway, :algorithm => 'HS256' }
 rescue JWT::ImmatureSignature
   # Handle invalid token, e.g. logout user or deny access
 end
@@ -337,6 +337,8 @@ From [Oauth JSON Web Token 4.1.6. "iat" (Issued At) Claim](https://tools.ietf.or
 
 > The `iat` (issued at) claim identifies the time at which the JWT was issued. This claim can be used to determine the age of the JWT. Its value MUST be a number containing a ***NumericDate*** value. Use of this claim is OPTIONAL.
 
+**Handle Issued At Claim**
+
 ```ruby
 iat = Time.now.to_i
 iat_payload = { :data => 'data', :iat => iat }
@@ -346,6 +348,25 @@ token = JWT.encode iat_payload, hmac_secret, 'HS256'
 begin
   # Add iat to the validation to check if the token has been manipulated
   decoded_token = JWT.decode token, hmac_secret, true, { :verify_iat => true, :algorithm => 'HS256' }
+rescue JWT::InvalidIatError
+  # Handle invalid token, e.g. logout user or deny access
+end
+```
+
+**Adding Leeway**
+
+```ruby
+iat = Time.now.to_i + 10
+leeway = 30 # seconds
+
+iat_payload = { :data => 'data', :iat => iat }
+
+# build token issued in the future
+token = JWT.encode iat_payload, hmac_secret, 'HS256'
+
+begin
+  # add leeway to ensure the token is accepted
+  decoded_token = JWT.decode token, hmac_secret, true, { :iat_leeway => leeway, :verify_iat => true, :algorithm => 'HS256' }
 rescue JWT::InvalidIatError
   # Handle invalid token, e.g. logout user or deny access
 end

--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -31,7 +31,7 @@ module JWT
     def verify_expiration
       return unless @payload.include?('exp')
 
-      if @payload['exp'].to_i <= (Time.now.to_i - leeway)
+      if @payload['exp'].to_i <= (Time.now.to_i - exp_leeway)
         raise(JWT::ExpiredSignature, 'Signature has expired')
       end
     end
@@ -39,7 +39,7 @@ module JWT
     def verify_iat
       return unless @payload.include?('iat')
 
-      if !@payload['iat'].is_a?(Numeric) || @payload['iat'].to_f > (Time.now.to_f + leeway)
+      if !@payload['iat'].is_a?(Numeric) || @payload['iat'].to_f > (Time.now.to_f + iat_leeway)
         raise(JWT::InvalidIatError, 'Invalid iat')
       end
     end
@@ -67,7 +67,7 @@ module JWT
     def verify_not_before
       return unless @payload.include?('nbf')
 
-      if @payload['nbf'].to_i > (Time.now.to_i + leeway)
+      if @payload['nbf'].to_i > (Time.now.to_i + nbf_leeway)
         raise(JWT::ImmatureSignature, 'Signature nbf has not been reached')
       end
     end
@@ -87,8 +87,20 @@ module JWT
       @options.values_at(key.to_sym, key.to_s).compact.first
     end
 
-    def leeway
+    def global_leeway
       extract_option :leeway
+    end
+
+    def exp_leeway
+      extract_option(:exp_leeway) || global_leeway
+    end
+
+    def iat_leeway
+      extract_option(:iat_leeway) || global_leeway
+    end
+
+    def nbf_leeway
+      extract_option(:nbf_leeway) || global_leeway
     end
   end
 end

--- a/spec/jwt/verify_spec.rb
+++ b/spec/jwt/verify_spec.rb
@@ -65,14 +65,14 @@ module JWT
 
       it 'should allow strings or symbols in options array' do
         options['aud'] = [
-          'ruby-jwt-aud', 
+          'ruby-jwt-aud',
           'test-aud',
           'ruby-ruby-ruby',
           :test
         ]
 
         array_payload['aud'].push('test')
-        
+
         Verify.verify_aud(array_payload, options)
       end
     end
@@ -87,8 +87,12 @@ module JWT
         end.to raise_error JWT::ExpiredSignature
       end
 
-      it 'must allow some leeway in the expiration when configured' do
+      it 'must allow some leeway in the expiration when global leeway is configured' do
         Verify.verify_expiration(payload, options.merge(leeway: 10))
+      end
+
+      it 'must allow some leeway in the expiration when exp_leeway is configured' do
+        Verify.verify_expiration(payload, options.merge(exp_leeway: 10))
       end
 
       it 'must be expired if the exp claim equals the current time' do
@@ -110,6 +114,10 @@ module JWT
 
       it 'must allow configured leeway' do
         Verify.verify_iat(payload.merge('iat' => (iat + 60)), options.merge(leeway: 70))
+      end
+
+      it 'must allow configured iat_leeway' do
+        Verify.verify_iat(payload.merge('iat' => (iat + 60)), options.merge(iat_leeway: 70))
       end
 
       it 'must properly handle integer times' do
@@ -191,8 +199,12 @@ module JWT
         end.to raise_error JWT::ImmatureSignature
       end
 
-      it 'must allow some leeway in the token age when configured' do
+      it 'must allow some leeway in the token age when global leeway is configured' do
         Verify.verify_not_before(payload, options.merge(leeway: 10))
+      end
+
+      it 'must allow some leeway in the token age when nbf_leeway is configured' do
+        Verify.verify_not_before(payload, options.merge(nbf_leeway: 10))
       end
     end
 


### PR DESCRIPTION
This PR intends to fix #129 by adding one independent leeway option for each claim.

I tried to make it backwards compatible by keeping the "global" `leeway` option (which is overwritten by each claim-specific leeway if they are present).

Let me know what you think