### PR TITLE
Move signature logic to its own module

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -6,6 +6,7 @@ require 'jwt/default_options'
 require 'jwt/encode'
 require 'jwt/error'
 require 'jwt/json'
+require 'jwt/signature'
 
 # JSON Web Token implementation
 #
@@ -17,49 +18,18 @@ module JWT
 
   module_function
 
-  def sign(algorithm, msg, key)
-    if %w(HS256 HS384 HS512).include?(algorithm)
-      sign_hmac(algorithm, msg, key)
-    elsif %w(RS256 RS384 RS512).include?(algorithm)
-      sign_rsa(algorithm, msg, key)
-    elsif %w(ES256 ES384 ES512).include?(algorithm)
-      sign_ecdsa(algorithm, msg, key)
-    else
-      raise NotImplementedError, 'Unsupported signing method'
-    end
-  end
-
-  def sign_rsa(algorithm, msg, private_key)
-    raise EncodeError, "The given key is a #{private_key.class}. It has to be an OpenSSL::PKey::RSA instance." if private_key.class == String
-    private_key.sign(OpenSSL::Digest.new(algorithm.sub('RS', 'sha')), msg)
-  end
-
-  def sign_ecdsa(algorithm, msg, private_key)
-    key_algorithm = NAMED_CURVES[private_key.group.curve_name]
-    if algorithm != key_algorithm
-      raise IncorrectAlgorithm, "payload algorithm is #{algorithm} but #{key_algorithm} signing key was provided"
-    end
-
-    digest = OpenSSL::Digest.new(algorithm.sub('ES', 'sha'))
-    asn1_to_raw(private_key.dsa_sign_asn1(digest.digest(msg)), private_key)
-  end
-
   def verify_rsa(algorithm, public_key, signing_input, signature)
     public_key.verify(OpenSSL::Digest.new(algorithm.sub('RS', 'sha')), signature, signing_input)
   end
 
   def verify_ecdsa(algorithm, public_key, signing_input, signature)
-    key_algorithm = NAMED_CURVES[public_key.group.curve_name]
+    key_algorithm = Signature::NAMED_CURVES[public_key.group.curve_name]
     if algorithm != key_algorithm
       raise IncorrectAlgorithm, "payload algorithm is #{algorithm} but #{key_algorithm} verification key was provided"
     end
 
     digest = OpenSSL::Digest.new(algorithm.sub('ES', 'sha'))
     public_key.dsa_verify_asn1(digest.digest(signing_input), raw_to_asn1(signature, public_key))
-  end
-
-  def sign_hmac(algorithm, msg, key)
-    OpenSSL::HMAC.digest(OpenSSL::Digest.new(algorithm.sub('HS', 'sha')), key, msg)
   end
 
   def decoded_segments(jwt, key = nil, verify = true, custom_options = {}, &keyfinder)
@@ -121,7 +91,7 @@ module JWT
 
   def verify_signature_algo(algo, key, signing_input, signature)
     if %w(HS256 HS384 HS512).include?(algo)
-      raise(JWT::VerificationError, 'Signature verification raised') unless secure_compare(signature, sign_hmac(algo, signing_input, key))
+      raise(JWT::VerificationError, 'Signature verification raised') unless secure_compare(signature, Signature.sign(algo, signing_input, key))
     elsif %w(RS256 RS384 RS512).include?(algo)
       raise(JWT::VerificationError, 'Signature verification raised') unless verify_rsa(algo, key, signing_input, signature)
     elsif %w(ES256 ES384 ES512).include?(algo)
@@ -146,11 +116,6 @@ module JWT
     r = signature[0..(byte_size - 1)]
     s = signature[byte_size..-1] || ''
     OpenSSL::ASN1::Sequence.new([r, s].map { |int| OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(int, 2)) }).to_der
-  end
-
-  def asn1_to_raw(signature, public_key)
-    byte_size = (public_key.group.degree + 7) / 8
-    OpenSSL::ASN1.decode(signature).value.map { |value| value.value.to_s(2).rjust(byte_size, "\x00") }.join
   end
 
   def base64url_decode(str)

--- a/lib/jwt/default_options.rb
+++ b/lib/jwt/default_options.rb
@@ -1,7 +1,5 @@
 module JWT
   module DefaultOptions
-    NAMED_CURVES = { 'prime256v1' => 'ES256', 'secp384r1' => 'ES384', 'secp521r1' => 'ES512' }.freeze
-
     DEFAULT_OPTIONS = {
       verify_expiration: true,
       verify_not_before: true,

--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -33,7 +33,7 @@ module JWT
       if algorithm == 'none'
         ''
       else
-        signature = JWT.sign(algorithm, signing_input, key)
+        signature = JWT::Signature.sign(algorithm, signing_input, key)
         JWT.base64url_encode(signature)
       end
     end

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require 'openssl'
+
+module JWT
+  module Signature
+    extend self
+
+    NAMED_CURVES = {
+      'prime256v1' => 'ES256',
+      'secp384r1' => 'ES384',
+      'secp521r1' => 'ES512'
+    }.freeze
+
+    def sign(algorithm, msg, key)
+      if %w(HS256 HS384 HS512).include?(algorithm)
+        sign_hmac(algorithm, msg, key)
+      elsif %w(RS256 RS384 RS512).include?(algorithm)
+        sign_rsa(algorithm, msg, key)
+      elsif %w(ES256 ES384 ES512).include?(algorithm)
+        sign_ecdsa(algorithm, msg, key)
+      else
+        raise NotImplementedError, 'Unsupported signing method'
+      end
+    end
+
+    private
+
+    def sign_rsa(algorithm, msg, private_key)
+      raise EncodeError, "The given key is a #{private_key.class}. It has to be an OpenSSL::PKey::RSA instance." if private_key.class == String
+      private_key.sign(OpenSSL::Digest.new(algorithm.sub('RS', 'sha')), msg)
+    end
+
+    def sign_ecdsa(algorithm, msg, private_key)
+      key_algorithm = NAMED_CURVES[private_key.group.curve_name]
+      if algorithm != key_algorithm
+        raise IncorrectAlgorithm, "payload algorithm is #{algorithm} but #{key_algorithm} signing key was provided"
+      end
+
+      digest = OpenSSL::Digest.new(algorithm.sub('ES', 'sha'))
+      asn1_to_raw(private_key.dsa_sign_asn1(digest.digest(msg)), private_key)
+    end
+
+    def sign_hmac(algorithm, msg, key)
+      OpenSSL::HMAC.digest(OpenSSL::Digest.new(algorithm.sub('HS', 'sha')), key, msg)
+    end
+
+    def asn1_to_raw(signature, public_key)
+      byte_size = (public_key.group.degree + 7) / 8
+      OpenSSL::ASN1.decode(signature).value.map { |value| value.value.to_s(2).rjust(byte_size, "\x00") }.join
+    end
+  end
+end

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -71,7 +71,7 @@ module JWT
     end
 
     def verify_ecdsa(algorithm, public_key, signing_input, signature)
-      key_algorithm = Signature::NAMED_CURVES[public_key.group.curve_name]
+      key_algorithm = NAMED_CURVES[public_key.group.curve_name]
       if algorithm != key_algorithm
         raise IncorrectAlgorithm, "payload algorithm is #{algorithm} but #{key_algorithm} verification key was provided"
       end

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -23,6 +23,14 @@ module JWT
       end
     end
 
+    def verify(algo, key, signing_input, signature)
+      verify_signature_algo(algo, key, signing_input, signature)
+    rescue OpenSSL::PKey::PKeyError
+      raise JWT::VerificationError, 'Signature verification raised'
+    ensure
+      OpenSSL.errors.clear
+    end
+
     private
 
     def sign_rsa(algorithm, msg, private_key)
@@ -44,9 +52,52 @@ module JWT
       OpenSSL::HMAC.digest(OpenSSL::Digest.new(algorithm.sub('HS', 'sha')), key, msg)
     end
 
+    def verify_signature_algo(algo, key, signing_input, signature)
+      if %w(HS256 HS384 HS512).include?(algo)
+        raise(JWT::VerificationError, 'Signature verification raised') unless secure_compare(signature, sign_hmac(algo, signing_input, key))
+      elsif %w(RS256 RS384 RS512).include?(algo)
+        raise(JWT::VerificationError, 'Signature verification raised') unless verify_rsa(algo, key, signing_input, signature)
+      elsif %w(ES256 ES384 ES512).include?(algo)
+        raise(JWT::VerificationError, 'Signature verification raised') unless verify_ecdsa(algo, key, signing_input, signature)
+      else
+        raise JWT::VerificationError, 'Algorithm not supported'
+      end
+    end
+
+    def verify_rsa(algorithm, public_key, signing_input, signature)
+      public_key.verify(OpenSSL::Digest.new(algorithm.sub('RS', 'sha')), signature, signing_input)
+    end
+
+    def verify_ecdsa(algorithm, public_key, signing_input, signature)
+      key_algorithm = Signature::NAMED_CURVES[public_key.group.curve_name]
+      if algorithm != key_algorithm
+        raise IncorrectAlgorithm, "payload algorithm is #{algorithm} but #{key_algorithm} verification key was provided"
+      end
+
+      digest = OpenSSL::Digest.new(algorithm.sub('ES', 'sha'))
+      public_key.dsa_verify_asn1(digest.digest(signing_input), raw_to_asn1(signature, public_key))
+    end
+
     def asn1_to_raw(signature, public_key)
       byte_size = (public_key.group.degree + 7) / 8
       OpenSSL::ASN1.decode(signature).value.map { |value| value.value.to_s(2).rjust(byte_size, "\x00") }.join
+    end
+
+    def raw_to_asn1(signature, private_key)
+      byte_size = (private_key.group.degree + 7) / 8
+      r = signature[0..(byte_size - 1)]
+      s = signature[byte_size..-1] || ''
+      OpenSSL::ASN1::Sequence.new([r, s].map { |int| OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(int, 2)) }).to_der
+    end
+
+    # From devise
+    # constant-time comparison algorithm to prevent timing attacks
+    def secure_compare(a, b)
+      return false if a.nil? || b.nil? || a.empty? || b.empty? || a.bytesize != b.bytesize
+      l = a.unpack "C#{a.bytesize}"
+      res = 0
+      b.each_byte { |byte| res |= byte ^ l.shift }
+      res.zero?
     end
   end
 end

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -78,7 +78,7 @@ describe JWT do
       it 'wrong secret should raise JWT::DecodeError' do
         expect do
           JWT.decode data[alg], 'wrong_secret', true, algorithm: alg
-        end.to raise_error JWT::DecodeError
+        end.to raise_error JWT::VerificationError
       end
 
       it 'wrong secret and verify = false should not raise JWT::DecodeError' do
@@ -226,23 +226,6 @@ describe JWT do
     it 'urlsafe replace + / with - _' do
       allow(Base64).to receive(:encode64) { 'string+with/non+url-safe/characters_' }
       expect(JWT.base64url_encode('foo')).to eq('string-with_non-url-safe_characters_')
-    end
-  end
-
-  describe 'secure comparison' do
-    it 'returns true if strings are equal' do
-      expect(JWT.secure_compare('Foo', 'Foo')).to eq true
-    end
-
-    it 'returns false if either input is nil or empty' do
-      [nil, ''].each do |bad|
-        expect(JWT.secure_compare(bad, 'Foo')).to eq false
-        expect(JWT.secure_compare('Foo', bad)).to eq false
-      end
-    end
-
-    it 'retuns false if the strings are different' do
-      expect(JWT.secure_compare('Foo', 'Bar')).to eq false
     end
   end
 end


### PR DESCRIPTION
Not sure if this change was planned, but seemed aligned with the rest of modules the gem has.
Also I think this will help to start working on redefining the public API (I guess that is planned for version 2).

Let me know what you think, if you want me to make changes, or if it's just not the direction you guys wanted to go.

Thanks!