### PR TITLE
Guard against partially loaded RbNaCl when failing to load libsodium

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ puts decoded_token
 
 Note: If [RbNaCl](https://github.com/cryptosphere/rbnacl) is loadable, ruby-jwt will use it for HMAC-SHA256, HMAC-SHA512/256, and HMAC-SHA512. RbNaCl enforces a maximum key size of 32 bytes for these algorithms.
 
+[RbNaCl](https://github.com/cryptosphere/rbnacl) requires
+[libsodium](https://github.com/jedisct1/libsodium), it can installed
+on MacOS with `brew install libsodium`.
+
 **RSA**
 
 * RS256 - RSA using SHA-256 hash algorithm

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -2,7 +2,8 @@
 require 'openssl'
 begin
   require 'rbnacl'
-rescue LoadError
+rescue LoadError => e
+  abort(e.message) if defined?(RbNaCl)
 end
 
 # JWT::Signature module


### PR DESCRIPTION
e.g. checking out the gem, running `bundle`, I got errors related to `RbNaCl::HMAC` not being loaded but `RbNaCl` being loaded.

Source was this silently ignored error (also mentioned in code climate) when loading `rbnacl`:

```
begin
  require 'rbnacl'
rescue LoadError
end
```

> Could not open library 'sodium': dlopen(sodium, 5): image not found.

> Could not open library 'libsodium.dylib': dlopen(libsodium.dylib, 5): image not found

Looking deeper, it was because `libsodium` was not installed on my system.

I personally think [`rbnacl-libsodium`](https://github.com/cryptosphere/rbnacl-libsodium) should be a dependency, then `rbnacl` could always be loaded.

An alternative would be to fix `rbnacl` to not leak a defined `RbNaCl` when it fails to load. Or removing the constant when loading the gem fails.

Thanks for this great gem
