### PR TITLE
Fix JWT.encode(nil)

### DIFF
--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -27,7 +27,7 @@ module JWT
     end
 
     def encoded_payload(payload)
-      raise InvalidPayload, 'exp claim must be an integer' if payload['exp'] && payload['exp'].is_a?(Time)
+      raise InvalidPayload, 'exp claim must be an integer' if payload && payload['exp'] && payload['exp'].is_a?(Time)
       Encode.base64url_encode(JSON.generate(payload))
     end
 


### PR DESCRIPTION
After https://github.com/jwt/ruby-jwt/commit/9c44e72dd8e8c6d9809eeaf4b601d58a86886cf4 in #164, it is no longer possible to encode a nil value.

This PR fixes the issue for `nil`. But it occurs to me that similar problems could occur if someone tried to encode an array.