### PR TITLE
Enforce `exp` to be an `Integer`

### DIFF
--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -27,7 +27,7 @@ module JWT
     end
 
     def encoded_payload(payload)
-      raise InvalidPayload, 'exp claim must be an integer' if payload && payload['exp'] && payload['exp'].is_a?(Time)
+      raise InvalidPayload, 'exp claim must be an integer' if payload && payload['exp'] && !payload['exp'].is_a?(Integer)
       Encode.base64url_encode(JSON.generate(payload))
     end
 

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -60,6 +60,14 @@ describe JWT do
         JWT.encode payload, nil, alg
       end.to raise_error JWT::InvalidPayload
     end
+
+    it 'should display a better error message if payload exp is not an Integer' do
+      payload['exp'] = Time.now.to_i.to_s
+
+      expect do
+        JWT.encode payload, nil, alg
+      end.to raise_error JWT::InvalidPayload
+    end
   end
 
   %w(HS256 HS512256 HS384 HS512).each do |alg|


### PR DESCRIPTION
The previous code was too permissive to accept different types that could be eventually serialized as a number, but that would require that whoever's is decoding the tokens that `exp` could be a `String`.