### PR TITLE
Fix typo in HS512256 algorithm description

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ puts decoded_token
 **HMAC** (default: HS256)
 
 * HS256 - HMAC using SHA-256 hash algorithm (default)
-* HS512256 - HMAC using SHA-512/256 hash algorithm (only available with RbNaCl; see note below)
+* HS512256 - HMAC using SHA-512-256 hash algorithm (only available with RbNaCl; see note below)
 * HS384 - HMAC using SHA-384 hash algorithm
 * HS512 - HMAC using SHA-512 hash algorithm
 
@@ -85,7 +85,7 @@ decoded_token = JWT.decode token, hmac_secret, true, { :algorithm => 'HS256' }
 puts decoded_token
 ```
 
-Note: If [RbNaCl](https://github.com/cryptosphere/rbnacl) is loadable, ruby-jwt will use it for HMAC-SHA256, HMAC-SHA512/256, and HMAC-SHA512. RbNaCl enforces a maximum key size of 32 bytes for these algorithms.
+Note: If [RbNaCl](https://github.com/cryptosphere/rbnacl) is loadable, ruby-jwt will use it for HMAC-SHA256, HMAC-SHA512-256, and HMAC-SHA512. RbNaCl enforces a maximum key size of 32 bytes for these algorithms.
 
 [RbNaCl](https://github.com/cryptosphere/rbnacl) requires
 [libsodium](https://github.com/jedisct1/libsodium), it can installed


### PR DESCRIPTION
HMAC-SHA-512-256 and HMAC-SHA-512/256 are different algorithms and libsodium actually supports only HMAC-SHA-512-256.