### PR TITLE
Use a default leeway of 0

### DIFF
--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -4,6 +4,10 @@ require 'jwt/error'
 module JWT
   # JWT verify methods
   class Verify
+    DEFAULTS = {
+      leeway: 0
+    }.freeze
+
     class << self
       %w(verify_aud verify_expiration verify_iat verify_iss verify_jti verify_not_before verify_sub).each do |method_name|
         define_method method_name do |payload, options|
@@ -21,7 +25,7 @@ module JWT
 
     def initialize(payload, options)
       @payload = payload
-      @options = options
+      @options = DEFAULTS.merge(options)
     end
 
     def verify_aud

--- a/spec/jwt/verify_spec.rb
+++ b/spec/jwt/verify_spec.rb
@@ -43,7 +43,6 @@ module JWT
     end
 
     context '.verify_expiration(payload, options)' do
-      let(:leeway) { 10 }
       let(:payload) { base_payload.merge('exp' => (Time.now.to_i - 5)) }
 
       it 'must raise JWT::ExpiredSignature when the token has expired' do
@@ -66,6 +65,16 @@ module JWT
         expect do
           Verify.verify_expiration(payload, options)
         end.to raise_error JWT::ExpiredSignature
+      end
+
+      context 'when leeway is not specified' do
+        let(:options) { {} }
+
+        it 'used a default leeway of 0' do
+          expect do
+            Verify.verify_expiration(payload, options)
+          end.to raise_error JWT::ExpiredSignature
+        end
       end
     end
 


### PR DESCRIPTION
This PR addresses https://github.com/jwt/ruby-jwt/issues/206. It sets up a hash of defaults (which simply has a `leeway` value). The spec I added fails with the error mentioned in the issue without this fix.