### PR TITLE
Add HS256 algorithm to decode default options

### DIFF
--- a/lib/jwt/default_options.rb
+++ b/lib/jwt/default_options.rb
@@ -8,7 +8,8 @@ module JWT
       verify_jti: false,
       verify_aud: false,
       verify_sub: false,
-      leeway: 0
+      leeway: 0,
+      algorithm: 'HS256'
     }.freeze
   end
 end

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -206,12 +206,15 @@ describe JWT do
         end.not_to raise_error
       end
 
-      it 'should raise JWT::IncorrectAlgorithm if no algorithm is provided' do
-        token = JWT.encode payload, data[:rsa_public].to_s, 'HS256'
+      context 'no algorithm provided' do
+        it 'should use the default decode algorithm' do
+          token = JWT.encode payload, data[:rsa_public].to_s
 
-        expect do
-          JWT.decode token, data[:rsa_public], true
-        end.to raise_error JWT::IncorrectAlgorithm
+          jwt_payload, header = JWT.decode token, data[:rsa_public].to_s
+
+          expect(header['alg']).to eq 'HS256'
+          expect(jwt_payload).to eq payload
+        end
       end
     end
 


### PR DESCRIPTION
# Things Done
- Added `algorithm: 'HS256'` to the JWT.decode default options list
- Added spec tests

Addresses Issue: #227 