### PR TITLE
Show backtrace if rbnacl-libsodium not loaded

### DIFF
--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -4,8 +4,8 @@ require 'jwt/security_utils'
 require 'openssl'
 begin
   require 'rbnacl'
-rescue LoadError => e
-  abort(e.message) if defined?(RbNaCl)
+rescue LoadError
+  raise if defined?(RbNaCl)
 end
 
 # JWT::Signature module


### PR DESCRIPTION
I think that backtrace should be shown to make to solve problem as easy when rbnacl-libsodium is not loaded.