### PR TITLE
Use case-compare for more flexibility in sub verification

### DIFF
--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -77,7 +77,7 @@ module JWT
     def verify_sub
       return unless (options_sub = @options[:sub])
       sub = @payload['sub']
-      raise(JWT::InvalidSubError, "Invalid subject. Expected #{options_sub}, received #{sub || '<none>'}") unless sub.to_s == options_sub.to_s
+      raise(JWT::InvalidSubError, "Invalid subject. Expected #{options_sub}, received #{sub || '<none>'}") unless options_sub === sub.to_s
     end
 
     private

--- a/spec/jwt/verify_spec.rb
+++ b/spec/jwt/verify_spec.rb
@@ -214,6 +214,10 @@ module JWT
       it 'must allow a matching sub' do
         Verify.verify_sub(base_payload.merge('sub' => sub), options.merge(sub: sub))
       end
+
+      it 'allows matching a sub with a regular expression' do
+        Verify.verify_sub(base_payload.merge('sub' => sub), options.merge(sub: /^ruby jwt/))
+      end
     end
   end
 end


### PR DESCRIPTION
I had a need to verify only the prefix of the sub claim. This PR changes the validation to perform a case compare, instead of casting to a string and doing exact equality.
