### PR TITLE
Support dynamic algorithm selection

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -42,7 +42,7 @@ module JWT
     algo, key = signature_algorithm_and_key(header, payload, key, &keyfinder)
 
     raise(JWT::IncorrectAlgorithm, 'An algorithm must be specified') unless options[:algorithm]
-    raise(JWT::IncorrectAlgorithm, 'Expected a different algorithm') unless algo == options[:algorithm]
+    raise(JWT::IncorrectAlgorithm, 'Expected a different algorithm') unless Array(options[:algorithm]).include?(algo)
 
     Signature.verify(algo, key, signing_input, signature)
   end


### PR DESCRIPTION
This is a follow-up to #172, which was intended to allow `keyfinder` to determine the decode key dynamically.  Adding the requirement to specify the algorithm causes a regression here, as the algorithm isn't known ahead of time.
There are a few ways to address this, but I think the simplest is just to allow the `algorithm` option to contain an array of supported algorithms, and only error if the request algorithm isn't in the list.