### PR TITLE
Allow a list of algorithms for decode

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -40,11 +40,9 @@ module JWT
 
   def decode_verify_signature(key, header, payload, signature, signing_input, options, &keyfinder)
     algo, key = signature_algorithm_and_key(header, payload, key, &keyfinder)
-    allowed_algorithms = options[:algorithms] || []
-    allowed_algorithms += [options[:algorithm]] if options.key?(:algorithm)
 
-    raise(JWT::IncorrectAlgorithm, 'An algorithm must be specified') if allowed_algorithms.empty?
-    raise(JWT::IncorrectAlgorithm, 'Expected a different algorithm') unless allowed_algorithms.include?(algo)
+    raise(JWT::IncorrectAlgorithm, 'An algorithm must be specified') if allowed_algorithms(options).empty?
+    raise(JWT::IncorrectAlgorithm, 'Expected a different algorithm') unless allowed_algorithms(options).include?(algo)
 
     Signature.verify(algo, key, signing_input, signature)
   end
@@ -59,5 +57,13 @@ module JWT
       raise JWT::DecodeError, 'No verification key available' unless key
     end
     [header['alg'], key]
+  end
+
+  def allowed_algorithms(options)
+    if options.key?(:algorithm)
+      [options[:algorithm]]
+    else
+      options[:algorithms] || []
+    end
   end
 end

--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -40,9 +40,11 @@ module JWT
 
   def decode_verify_signature(key, header, payload, signature, signing_input, options, &keyfinder)
     algo, key = signature_algorithm_and_key(header, payload, key, &keyfinder)
+    allowed_algorithms = options[:algorithms] || []
+    allowed_algorithms += [options[:algorithm]] if options.key?(:algorithm)
 
-    raise(JWT::IncorrectAlgorithm, 'An algorithm must be specified') unless options[:algorithm]
-    raise(JWT::IncorrectAlgorithm, 'Expected a different algorithm') unless algo == options[:algorithm]
+    raise(JWT::IncorrectAlgorithm, 'An algorithm must be specified') if allowed_algorithms.empty?
+    raise(JWT::IncorrectAlgorithm, 'Expected a different algorithm') unless allowed_algorithms.include?(algo)
 
     Signature.verify(algo, key, signing_input, signature)
   end

--- a/lib/jwt/default_options.rb
+++ b/lib/jwt/default_options.rb
@@ -9,7 +9,7 @@ module JWT
       verify_aud: false,
       verify_sub: false,
       leeway: 0,
-      algorithm: 'HS256'
+      algorithms: ['HS256']
     }.freeze
   end
 end

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -235,7 +235,7 @@ describe JWT do
         token = JWT.encode payload, data[:secret], 'HS512'
 
         expect do
-          JWT.decode token, data[:secret], true, algorithms: 'HS384'
+          JWT.decode token, data[:secret], true, algorithm: 'HS384'
         end.to raise_error JWT::IncorrectAlgorithm
 
         expect do

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -232,14 +232,14 @@ describe JWT do
   context 'Verify' do
     context 'algorithm' do
       it 'should raise JWT::IncorrectAlgorithm on mismatch' do
-        token = JWT.encode payload, data[:secret], 'HS512'
+        token = JWT.encode payload, data[:secret], 'HS256'
 
         expect do
           JWT.decode token, data[:secret], true, algorithm: 'HS384'
         end.to raise_error JWT::IncorrectAlgorithm
 
         expect do
-          JWT.decode token, data[:secret], true, algorithm: 'HS512'
+          JWT.decode token, data[:secret], true, algorithm: 'HS256'
         end.not_to raise_error
       end
 

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -231,15 +231,27 @@ describe JWT do
 
   context 'Verify' do
     context 'algorithm' do
-      it 'should raise JWT::IncorrectAlgorithm on missmatch' do
+      it 'should raise JWT::IncorrectAlgorithm on mismatch' do
         token = JWT.encode payload, data[:secret], 'HS512'
 
         expect do
-          JWT.decode token, data[:secret], true, algorithm: 'HS384'
+          JWT.decode token, data[:secret], true, algorithms: 'HS384'
         end.to raise_error JWT::IncorrectAlgorithm
 
         expect do
           JWT.decode token, data[:secret], true, algorithm: 'HS512'
+        end.not_to raise_error
+      end
+
+      it 'should raise JWT::IncorrectAlgorithm when algorithms array does not contain algorithm' do
+        token = JWT.encode payload, data[:secret], 'HS512'
+
+        expect do
+          JWT.decode token, data[:secret], true, algorithms: ['HS384']
+        end.to raise_error JWT::IncorrectAlgorithm
+
+        expect do
+          JWT.decode token, data[:secret], true, algorithms: ['HS512', 'HS384']
         end.not_to raise_error
       end
 


### PR DESCRIPTION
Hard-coding only one algorithms makes rolling out changes harder. Both ends need to be deployed simultaneously or retry logic needs to be implemented in app.

Allowing the algorithms to be a list containing potentially multiple entries enables flexibility when changing algorithms. The default value is left unchanged and giving `:algorithm` option instead of  `:algorithms` still works.