### PR TITLE
Add note about using a hard coded algorithm in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ And run `bundle install`
 
 ## Algorithms and Usage
 
-The JWT spec supports NONE, HMAC, RSASSA, ECDSA and RSASSA-PSS algorithms for cryptographic signing. Currently the jwt gem supports NONE, HMAC, RSASSA and ECDSA. If you are using cryptographic signing, you need to specify the algorithm in the options hash whenever you call JWT.decode to ensure that an attacker [cannot bypass the algorithm verification step](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/).
+The JWT spec supports NONE, HMAC, RSASSA, ECDSA and RSASSA-PSS algorithms for cryptographic signing. Currently the jwt gem supports NONE, HMAC, RSASSA and ECDSA. If you are using cryptographic signing, you need to specify the algorithm in the options hash whenever you call JWT.decode to ensure that an attacker [cannot bypass the algorithm verification step](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/). **It is strongly recommended that you hard code the algorithm, as you may leave yourself vulnerable by dynamically picking the algorithm**
 
 See: [ JSON Web Algorithms (JWA) 3.1. "alg" (Algorithm) Header Parameter Values for JWS](https://tools.ietf.org/html/rfc7518#section-3.1)
 


### PR DESCRIPTION
I've seen code 'working around' the added security of algorithm parameter by extracting the algorithm from the JWT without verification first, and then passing that algorithm into the JWT verification.

Unfortunately, I don't think there's really a good way to programmatically enforce such a thing. You may be able to require the parameter to be a literal string or a symbol, but I don't know how effective that'd work in practice.

At the very least, I think it's worth adding an additional note in the readme about the algorithm to be more clear for those that don't click into the linked article.