### PR TITLE
Add RSASSA-PSS signature signing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ decoded_token = JWT.decode token, public_key, true, { algorithm: 'ED25519' }
 
 **RSASSA-PSS**
 
+In order to use this algorithm you need to add the `openssl` gem to you `Gemfile` with a version greater or equal to `2.1`.
+
+```ruby
+gem 'openssl', '~> 2.1'
+```
+
 * PS256 - RSASSA-PSS using SHA-256 hash algorithm
 * PS384 - RSASSA-PSS using SHA-384 hash algorithm
 * PS512 - RSASSA-PSS using SHA-512 hash algorithm

--- a/README.md
+++ b/README.md
@@ -176,7 +176,28 @@ decoded_token = JWT.decode token, public_key, true, { algorithm: 'ED25519' }
 
 **RSASSA-PSS**
 
-Not implemented.
+* PS256 - RSASSA-PSS using SHA-256 hash algorithm
+* PS384 - RSASSA-PSS using SHA-384 hash algorithm
+* PS512 - RSASSA-PSS using SHA-512 hash algorithm
+
+```ruby
+rsa_private = OpenSSL::PKey::RSA.generate 2048
+rsa_public = rsa_private.public_key
+
+token = JWT.encode payload, rsa_private, 'PS256'
+
+# eyJhbGciOiJQUzI1NiJ9.eyJkYXRhIjoidGVzdCJ9.KEmqagMUHM-NcmXo6818ZazVTIAkn9qU9KQFT1c5Iq91n0KRpAI84jj4ZCdkysDlWokFs3Dmn4MhcXP03oJKLFgnoPL40_Wgg9iFr0jnIVvnMUp1kp2RFUbL0jqExGTRA3LdAhuvw6ZByGD1bkcWjDXygjQw-hxILrT1bENjdr0JhFd-cB0-ps5SB0mwhFNcUw-OM3Uu30B1-mlFaelUY8jHJYKwLTZPNxHzndt8RGXF8iZLp7dGb06HSCKMcVzhASGMH4ZdFystRe2hh31cwcvnl-Eo_D4cdwmpN3Abhk_8rkxawQJR3duh8HNKc4AyFPo7SabEaSu2gLnLfN3yfg
+puts token
+
+decoded_token = JWT.decode token, rsa_public, true, { algorithm: 'PS256' }
+
+# Array
+# [
+#   {"data"=>"test"}, # payload
+#   {"alg"=>"PS256"} # header
+# ]
+puts decoded_token
+```
 
 ## Support for reserved claim names
 JSON Web Token defines some reserved claim names and defines how they should be

--- a/lib/jwt/algos/ps.rb
+++ b/lib/jwt/algos/ps.rb
@@ -1,11 +1,15 @@
 module JWT
   module Algos
     module Ps
+      # RSASSA-PSS signing algorithms
+
       module_function
 
       SUPPORTED = %w[PS256 PS384 PS512].freeze
 
       def sign(to_sign)
+        require_openssl!
+
         algorithm, msg, key = to_sign.values
 
         key_class = key.class
@@ -18,7 +22,15 @@ module JWT
       end
 
       def verify(to_verify)
+        require_openssl!
+
         SecurityUtils.verify_ps(to_verify.algorithm, to_verify.public_key, to_verify.signing_input, to_verify.signature)
+      end
+
+      def require_openssl!
+        unless Gem.loaded_specs['openssl'] && Gem.loaded_specs['openssl'].version.release >= Gem::Version.new('2.1')
+          raise JWT::RequiredGemError, 'OpenSSL +2.1 is required to support RSASSA-PSS algorithms'
+        end
       end
     end
   end

--- a/lib/jwt/algos/ps.rb
+++ b/lib/jwt/algos/ps.rb
@@ -28,7 +28,9 @@ module JWT
       end
 
       def require_openssl!
-        unless Gem.loaded_specs['openssl'] && Gem.loaded_specs['openssl'].version.release >= Gem::Version.new('2.1')
+        openssl_gem = Gem.loaded_specs['openssl']
+
+        unless openssl_gem && openssl_gem.version.release >= Gem::Version.new('2.1')
           raise JWT::RequiredGemError, 'OpenSSL +2.1 is required to support RSASSA-PSS algorithms'
         end
       end

--- a/lib/jwt/algos/ps.rb
+++ b/lib/jwt/algos/ps.rb
@@ -1,0 +1,20 @@
+module JWT
+  module Algos
+    module Ps
+      module_function
+
+      SUPPORTED = %w[PS256 PS384 PS512].freeze
+
+      def sign(to_sign)
+        algorithm, msg, key = to_sign.values
+        raise EncodeError, "The given key is a #{key.class}. It has to be an OpenSSL::PKey::RSA instance." if key.class == String
+
+        key.sign_pss(algorithm.sub('PS', 'sha'), msg, salt_length: :max, mgf1_hash: algorithm.sub('PS', 'sha'))
+      end
+
+      def verify(to_verify)
+        SecurityUtils.verify_ps(to_verify.algorithm, to_verify.public_key, to_verify.signing_input, to_verify.signature)
+      end
+    end
+  end
+end

--- a/lib/jwt/algos/ps.rb
+++ b/lib/jwt/algos/ps.rb
@@ -7,9 +7,14 @@ module JWT
 
       def sign(to_sign)
         algorithm, msg, key = to_sign.values
-        raise EncodeError, "The given key is a #{key.class}. It has to be an OpenSSL::PKey::RSA instance." if key.class == String
 
-        key.sign_pss(algorithm.sub('PS', 'sha'), msg, salt_length: :max, mgf1_hash: algorithm.sub('PS', 'sha'))
+        key_class = key.class
+
+        raise EncodeError, "The given key is a #{key_class}. It has to be an OpenSSL::PKey::RSA instance." if key_class == String
+
+        translated_algorithm = algorithm.sub('PS', 'sha')
+
+        key.sign_pss(translated_algorithm, msg, salt_length: :max, mgf1_hash: translated_algorithm)
       end
 
       def verify(to_verify)

--- a/lib/jwt/algos/ps.rb
+++ b/lib/jwt/algos/ps.rb
@@ -28,10 +28,14 @@ module JWT
       end
 
       def require_openssl!
-        openssl_gem = Gem.loaded_specs['openssl']
+        if Object.const_defined?('OpenSSL')
+          major, minor = OpenSSL::VERSION.split('.').first(2)
 
-        unless openssl_gem && openssl_gem.version.release >= Gem::Version.new('2.1')
-          raise JWT::RequiredGemError, 'OpenSSL +2.1 is required to support RSASSA-PSS algorithms'
+          unless major.to_i >= 2 && minor.to_i >= 1
+            raise JWT::RequiredDependencyError, "You currently have OpenSSL #{OpenSSL::VERSION}. PS support requires >= 2.1"
+          end
+        else
+          raise JWT::RequiredDependencyError, 'PS signing requires OpenSSL +2.1'
         end
       end
     end

--- a/lib/jwt/error.rb
+++ b/lib/jwt/error.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module JWT
-  EncodeError      = Class.new(StandardError)
-  DecodeError      = Class.new(StandardError)
-  RequiredGemError = Class.new(StandardError)
+  EncodeError             = Class.new(StandardError)
+  DecodeError             = Class.new(StandardError)
+  RequiredDependencyError = Class.new(StandardError)
 
   VerificationError  = Class.new(DecodeError)
   ExpiredSignature   = Class.new(DecodeError)

--- a/lib/jwt/error.rb
+++ b/lib/jwt/error.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 module JWT
-  EncodeError = Class.new(StandardError)
-  DecodeError = Class.new(StandardError)
+  EncodeError      = Class.new(StandardError)
+  DecodeError      = Class.new(StandardError)
+  RequiredGemError = Class.new(StandardError)
 
   VerificationError  = Class.new(DecodeError)
   ExpiredSignature   = Class.new(DecodeError)

--- a/lib/jwt/security_utils.rb
+++ b/lib/jwt/security_utils.rb
@@ -20,6 +20,12 @@ module JWT
       public_key.verify(OpenSSL::Digest.new(algorithm.sub('RS', 'sha')), signature, signing_input)
     end
 
+    def verify_ps(algorithm, public_key, signing_input, signature)
+      formatted_algorithm = algorithm.sub('PS', 'sha')
+
+      public_key.verify_pss(formatted_algorithm, signature, signing_input, salt_length: :auto, mgf1_hash: formatted_algorithm)
+    end
+
     def asn1_to_raw(signature, public_key)
       byte_size = (public_key.group.degree + 7) / 8
       OpenSSL::ASN1.decode(signature).value.map { |value| value.value.to_s(2).rjust(byte_size, "\x00") }.join

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -6,6 +6,7 @@ require 'jwt/algos/hmac'
 require 'jwt/algos/eddsa'
 require 'jwt/algos/ecdsa'
 require 'jwt/algos/rsa'
+require 'jwt/algos/ps'
 require 'jwt/algos/unsupported'
 begin
   require 'rbnacl'
@@ -23,6 +24,7 @@ module JWT
       Algos::Ecdsa,
       Algos::Rsa,
       Algos::Eddsa,
+      Algos::Ps,
       Algos::Unsupported
     ].freeze
     ToSign = Struct.new(:algorithm, :msg, :key)

--- a/ruby-jwt.gemspec
+++ b/ruby-jwt.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'codacy-coverage'
   spec.add_development_dependency 'rbnacl'
-
   # RSASSA-PSS support provided by OpenSSL +2.1
-  spec.add_runtime_dependency 'openssl', '~> 2.1'
+  spec.add_development_dependency 'openssl', '~> 2.1'
 end

--- a/ruby-jwt.gemspec
+++ b/ruby-jwt.gemspec
@@ -29,4 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'codacy-coverage'
   spec.add_development_dependency 'rbnacl'
+
+  # RSASSA-PSS support provided by OpenSSL +2.1
+  spec.add_runtime_dependency 'openssl', '~> 2.1'
 end

--- a/spec/integration/readme_examples_spec.rb
+++ b/spec/integration/readme_examples_spec.rb
@@ -56,6 +56,19 @@ describe 'README.md code test' do
         { 'alg' => 'ES256' }
       ]
     end
+
+    it 'RSASSA-PSS' do
+      rsa_private = OpenSSL::PKey::RSA.generate 2048
+      rsa_public = rsa_private.public_key
+
+      token = JWT.encode payload, rsa_private, 'PS256'
+      decoded_token = JWT.decode token, rsa_public, true, algorithm: 'PS256'
+
+      expect(decoded_token).to eq [
+        { 'data' => 'test' },
+        { 'alg' => 'PS256' }
+      ]
+    end
   end
 
   context 'claims' do


### PR DESCRIPTION
### Changes
- Adds support for `PS256`, `PS384`, and `PS512` signing algorithms. **Note** As can be seen from the changes in the `gemspec`, a requirement for `OpenSSL` `+2.1` is made, as older versions do not include the native support for RSASSA-PSS. We understand that there can be pushback on this requirement, and are thus open to ways of making the dependency optional or removing it and leaving it up to the client of the gem to handle this dependecy.
- Updates `README` with examples of `PS*` signing.
- Adds specs for `PS*` signing of JWTs. 

