### PR TITLE
Drop Ruby 2.2 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: bundler
 dist: trusty
 language: ruby
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5


### PR DESCRIPTION
The introduction of the [openssl](https://rubygems.org/gems/openssl) gem broke the Ruby 2.2 build because the gem is not compatible with Ruby 2.2 anymore.

As Ruby 2.2 is not [supported](https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/) anymore the easiest fix is just to stop running the test against that version.
