### PR TITLE
Make sure alg parameter value isn't added twice

### DIFF
--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -39,7 +39,7 @@ module JWT
     end
 
     def encode_header
-      encode(@headers.merge(ALG_KEY => @algorithm))
+      encode(@headers.transform_keys(&:to_s).merge(ALG_KEY => @algorithm))
     end
 
     def encode_payload

--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -39,7 +39,13 @@ module JWT
     end
 
     def encode_header
-      encode(@headers.transform_keys(&:to_s).merge(ALG_KEY => @algorithm))
+      stringified_header = {}
+
+      @headers.each do |key, value|
+        stringified_header[key.to_s] = value
+      end
+
+      encode(stringified_header.merge(ALG_KEY => @algorithm))
     end
 
     def encode_payload

--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -13,7 +13,7 @@ module JWT
       @payload   = options[:payload]
       @key       = options[:key]
       @algorithm = options[:algorithm]
-      @headers   = options[:headers].each_with_object({}) { |(k, v), h| h[k.to_s] = v }
+      @headers   = options[:headers].each_with_object({}) { |(key, value), headers| headers[key.to_s] = value }
     end
 
     def segments

--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -13,7 +13,7 @@ module JWT
       @payload   = options[:payload]
       @key       = options[:key]
       @algorithm = options[:algorithm]
-      @headers   = options[:headers]
+      @headers   = options[:headers].each_with_object({}) { |(k, v), h| h[k.to_s] = v }
     end
 
     def segments
@@ -39,13 +39,8 @@ module JWT
     end
 
     def encode_header
-      stringified_header = {}
-
-      @headers.each do |key, value|
-        stringified_header[key.to_s] = value
-      end
-
-      encode(stringified_header.merge(ALG_KEY => @algorithm))
+      @headers[ALG_KEY] = @algorithm
+      encode(@headers)
     end
 
     def encode_payload

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -399,5 +399,9 @@ describe JWT do
       headers = JSON.parse(::JWT::Base64.url_decode(JWT.encode('Hello World', 'secret', 'HS256', { alg: 'HS123'}).split('.').first))
       expect(headers['alg']).to eq('HS256')
     end
+
+    it "should generate the same token" do
+      expect(JWT.encode('Hello World', 'secret', 'HS256', { alg: 'HS256'})).to eq JWT.encode('Hello World', 'secret', 'HS256')
+    end
   end
 end


### PR DESCRIPTION
The `alg` parameter key (`ALG_KEY`) is a string, and added to the header hash as such (`{ "alg" =>  "foo" }`). If it's already in the header hash, but as a symbol (`{ alg: "foo"}), it's appended to the this hash (`{ alg: "foo", "alg" => "foo"}`) resulting in the end in a different token.

We noticed Apple's Mapkit JS complaing about this.

This PR fixes this. 


