### PR TITLE
Add support for Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 gemfiles:
   - gemfiles/standalone.gemfile
   - gemfiles/rails_5.0.gemfile


### PR DESCRIPTION
## What

Add support for Ruby 2.6.

## How

Including 2.6 in the Travis execution matrix.