### PR TITLE
Fix Salt length for conformance with PS family specification.

### DIFF
--- a/lib/jwt/algos/ps.rb
+++ b/lib/jwt/algos/ps.rb
@@ -18,7 +18,7 @@ module JWT
 
         translated_algorithm = algorithm.sub('PS', 'sha')
 
-        key.sign_pss(translated_algorithm, msg, salt_length: :max, mgf1_hash: translated_algorithm)
+        key.sign_pss(translated_algorithm, msg, salt_length: :digest, mgf1_hash: translated_algorithm)
       end
 
       def verify(to_verify)


### PR DESCRIPTION
[RFC 7518 Section 3.5](https://tools.ietf.org/html/rfc7518#section-3.5) specifies

> The size of the salt value is the same size as the hash function output.

It was missed in @oliver-hohn's original PR (#285) - as such created JWTs were being treated as non-conformant by PS-speaking OIDC clients.

With this parameter set, we are able to validate the JWT signature using standard tools such as jwt.io, and access PS256-requiring APIs.

Apologies for the original mistake here, and I'm not _quite_ sure how we can add tests to defend against any future problems in this area but will be happy to take suggestions if we feel this is needed.