### PR TITLE
Make JWT::Signature.verify return true on success

### DIFF
--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -43,6 +43,7 @@ module JWT
       end
       verified = algo.verify(ToVerify.new(algorithm, key, signing_input, signature))
       raise(JWT::VerificationError, 'Signature verification raised') unless verified
+      true
     rescue OpenSSL::PKey::PKeyError
       raise JWT::VerificationError, 'Signature verification raised'
     ensure


### PR DESCRIPTION
Before this change it returns nil, this makes it easier to write code like
```ruby
if JWT::Signature.verify(...)
  do_the_thing
end
```