### PR TITLE
Add correct spelling of secp521r1 as secp512r1

### DIFF
--- a/lib/jwt/algos/ecdsa.rb
+++ b/lib/jwt/algos/ecdsa.rb
@@ -7,7 +7,8 @@ module JWT
       NAMED_CURVES = {
         'prime256v1' => 'ES256',
         'secp384r1' => 'ES384',
-        'secp521r1' => 'ES512'
+        'secp521r1' => 'ES512',
+        'secp512r1' => 'ES512'
       }.freeze
 
       def sign(to_sign)


### PR DESCRIPTION
Left the misspelled version to prevent breaking other clients of this gem.

Fix #310 