### PR TITLE
Improvement/encode hmac without key

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ decoded_token = JWT.decode token, hmac_secret, true, { algorithm: 'HS256' }
 #   {"alg"=>"HS256"} # header
 # ]
 puts decoded_token
+
+# Without secret key
+token = JWT.encode payload, nil, 'HS256'
+
+# eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjoidGVzdCJ9.pVzcY2dX8JNM3LzIYeP2B1e1Wcpt1K3TWVvIYSF4x-o
+puts token
+
+decoded_token = JWT.decode token, nil, true, { algorithm: 'HS256' }
+
+# Array
+# [
+#   {"data"=>"test"}, # payload
+#   {"alg"=>"HS256"} # header
+# ]
+puts decoded_token
 ```
 
 Note: If [RbNaCl](https://github.com/cryptosphere/rbnacl) is loadable, ruby-jwt will use it for HMAC-SHA256, HMAC-SHA512-256, and HMAC-SHA512. RbNaCl enforces a maximum key size of 32 bytes for these algorithms.
@@ -460,7 +475,7 @@ begin
 rescue JWT::JWKError
   # Handle problems with the provided JWKs
 rescue JWT::DecodeError
-  # Handle other decode related issues e.g. no kid in header, no matching public key found etc. 
+  # Handle other decode related issues e.g. no kid in header, no matching public key found etc.
 end
 ```
 

--- a/lib/jwt/algos/hmac.rb
+++ b/lib/jwt/algos/hmac.rb
@@ -7,6 +7,7 @@ module JWT
 
       def sign(to_sign)
         algorithm, msg, key = to_sign.values
+        key ||= ''
         authenticator, padded_key = SecurityUtils.rbnacl_fixup(algorithm, key)
         if authenticator && padded_key
           authenticator.auth(padded_key, msg.encode('binary'))

--- a/spec/integration/readme_examples_spec.rb
+++ b/spec/integration/readme_examples_spec.rb
@@ -18,11 +18,22 @@ describe 'README.md code test' do
       ]
     end
 
-    it 'HMAC' do
+    it 'decodes with HMAC algorithm with secret key' do
       token = JWT.encode payload, 'my$ecretK3y', 'HS256'
       decoded_token = JWT.decode token, 'my$ecretK3y', false
 
       expect(token).to eq 'eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjoidGVzdCJ9.pNIWIL34Jo13LViZAJACzK6Yf0qnvT_BuwOxiMCPE-Y'
+      expect(decoded_token).to eq [
+        { 'data' => 'test' },
+        { 'alg' => 'HS256' }
+      ]
+    end
+
+    it 'decodes with HMAC algorithm without secret key' do
+      token = JWT.encode payload, nil, 'HS256'
+      decoded_token = JWT.decode token, nil, false
+
+      expect(token).to eq 'eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjoidGVzdCJ9.pVzcY2dX8JNM3LzIYeP2B1e1Wcpt1K3TWVvIYSF4x-o'
       expect(decoded_token).to eq [
         { 'data' => 'test' },
         { 'alg' => 'HS256' }

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -404,4 +404,17 @@ describe JWT do
       expect(JWT.encode('Hello World', 'secret', 'HS256', { alg: 'HS256'})).to eq JWT.encode('Hello World', 'secret', 'HS256')
     end
   end
+
+  context 'when hmac algorithm is used without secret key' do
+    it 'encodes payload' do
+      payload = { a: 1, b: 'b'}
+
+      token = JWT.encode(payload, '', 'HS256')
+
+      expect do
+        token_without_secret = JWT.encode(payload, nil, 'HS256')
+        expect(token).to eq(token_without_secret)
+      end.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
# Description

  For `hmac` strategy, will raise an exception if the secret key is `nil` but no when secret key is blank, for both cases should be the same.

# Analysis

  in `lib/jwt/algos/hmac.rb`the key value is used for 
```ruby
SecurityUtils.rbnacl_fixup(algorithm, key.to_s)
```
and 
```ruby
OpenSSL::HMAC.digest(OpenSSL::Digest.new(algorithm.sub('HS', 'sha')), key.to_s, msg)
```

in both cases, the key should be a `string` for https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/HMAC.html and
```ruby
# lib/jwt/security_utils.rb:49
# lib/jwt/security_utils.rb:53
key.bytesize
``` 

 # Solution:

in `JWT::Algos::Hmac#sign` set `key ||= ''` to convert `nil` to `String`

# QA

* Run tests
* `bin/console.rb` =>
```ruby
# Without secret key
token = JWT.encode payload, nil, 'HS256'

# eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjoidGVzdCJ9.pVzcY2dX8JNM3LzIYeP2B1e1Wcpt1K3TWVvIYSF4x-o
puts token

decoded_token = JWT.decode token, nil, true, { algorithm: 'HS256' }

# Array
# [
#   {"data"=>"test"}, # payload
#   {"alg"=>"HS256"} # header
# ]
puts decoded_token
```