### PR TITLE
Preserve JWK kid on import

### DIFF
--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -8,19 +8,21 @@ module JWT
       extend Forwardable
 
       attr_reader :keypair
+      attr_reader :jwk_kid
 
       def_delegators :keypair, :private?, :public_key
 
       BINARY = 2
       KTY    = 'RSA'.freeze
 
-      def initialize(keypair)
+      def initialize(keypair, kid = nil)
         raise ArgumentError, 'keypair must be of type OpenSSL::PKey::RSA' unless keypair.is_a?(OpenSSL::PKey::RSA)
-
+        @jwk_kid = kid
         @keypair = keypair
       end
 
       def kid
+        return jwk_kid if jwk_kid
         sequence = OpenSSL::ASN1::Sequence([OpenSSL::ASN1::Integer.new(public_key.n),
                                             OpenSSL::ASN1::Integer.new(public_key.e)])
         OpenSSL::Digest::SHA256.hexdigest(sequence.to_der)
@@ -40,7 +42,7 @@ module JWT
         imported_key.set_key(OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:n]), BINARY),
           OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:e]), BINARY),
           nil)
-        self.new(imported_key)
+        self.new(imported_key, jwk_data[:kid])
       end
     end
   end

--- a/spec/jwk_spec.rb
+++ b/spec/jwk_spec.rb
@@ -24,6 +24,13 @@ describe JWT::JWK do
         expect { subject }.to raise_error(JWT::JWKError)
       end
     end
+
+    context 'when keypair with defined kid is imported' do
+      it 'returns the predefined kid if jwt_data contains a kid' do
+        params[:kid] = "CUSTOM_KID"
+        expect(subject.export).to eq(params)
+      end
+    end
   end
 
   describe '.to_jwk' do


### PR DESCRIPTION
From issue #313 

The JWK `import` method generates a unique kid on export, but doesn't take the imported kid into account. The logic here allows an imported kid to be included on export, while allowing a kid to be generated if none is present.