### PR TITLE
Allow Numeric values during encoding

### DIFF
--- a/lib/jwt/claims_validator.rb
+++ b/lib/jwt/claims_validator.rb
@@ -2,7 +2,7 @@ require_relative './error'
 
 module JWT
   class ClaimsValidator
-    INTEGER_CLAIMS = %i[
+    NUMERIC_CLAIMS = %i[
       exp
       iat
       nbf
@@ -13,21 +13,23 @@ module JWT
     end
 
     def validate!
-      validate_int_claims
+      validate_numeric_claims
 
       true
     end
 
     private
 
-    def validate_int_claims
-      INTEGER_CLAIMS.each do |claim|
-        validate_is_int(claim) if @payload.key?(claim)
+    def validate_numeric_claims
+      NUMERIC_CLAIMS.each do |claim|
+        validate_is_numeric(claim) if @payload.key?(claim)
       end
     end
 
-    def validate_is_int(claim)
-      raise InvalidPayload, "#{claim} claim must be an Integer but it is a #{@payload[claim].class}" unless @payload[claim].is_a?(Integer)
+    def validate_is_numeric(claim)
+      return if @payload[claim].is_a?(Numeric)
+
+      raise InvalidPayload, "#{claim} claim must be a Numeric value but it is a #{@payload[claim].class}"
     end
   end
 end


### PR DESCRIPTION
Hi!

According to this https://github.com/jwt/ruby-jwt/pull/134 and the sources linked there, `exp`, `nbf` and `iat` claims are `NumericDate`s, not integers.

This PR allows numeric values for those claims during token creation.

I'm not sure where the validator was added, but I discovered the issue while upgrading from `1.x` to `2.x` - in `1.x` float values were allowed.