### PR TITLE
Support RSA.import for all Ruby versions.

### DIFF
--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -39,9 +39,14 @@ module JWT
 
       def self.import(jwk_data)
         imported_key = OpenSSL::PKey::RSA.new
-        imported_key.set_key(OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:n]), BINARY),
-          OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:e]), BINARY),
-          nil)
+        if imported_key.respond_to?(:set_key)
+          imported_key.set_key(OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:n]), BINARY),
+            OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:e]), BINARY),
+            nil)
+        else
+          imported_key.n = OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:n]), BINARY)
+          imported_key.e = OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:e]), BINARY)
+        end
         self.new(imported_key)
       end
     end


### PR DESCRIPTION
For Ruby versions < 2.4.0:
```
2.3.5 :006 > OpenSSL::PKey::RSA.new.respond_to?(:set_key)
 => false
```

This patch makes sure that RSA.import method is supported for all versions of Ruby. 