### PR TITLE
Handle parsed JSON JWKS input with string keys

### DIFF
--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -12,9 +12,10 @@ module JWT
 
     class << self
       def import(jwk_data)
-        raise JWT::JWKError, 'Key type (kty) not provided' unless jwk_data[:kty]
+        jwk_kty = jwk_data[:kty] || jwk_data['kty']
+        raise JWT::JWKError, 'Key type (kty) not provided' unless jwk_kty
 
-        MAPPINGS.fetch(jwk_data[:kty].to_s) do |kty|
+        MAPPINGS.fetch(jwk_kty.to_s) do |kty|
           raise JWT::JWKError, "Key type #{kty} not supported"
         end.import(jwk_data)
       end

--- a/lib/jwt/jwk/key_finder.rb
+++ b/lib/jwt/jwk/key_finder.rb
@@ -14,10 +14,8 @@ module JWT
 
         jwk = resolve_key(kid)
 
-        unless jwk
-          raise ::JWT::DecodeError, 'No keys found in jwks' if jwks_keys.empty?
-          raise ::JWT::DecodeError, "Could not find public key for kid #{kid}"
-        end
+        raise ::JWT::DecodeError, 'No keys found in jwks' if jwks_keys.empty?
+        raise ::JWT::DecodeError, "Could not find public key for kid #{kid}" unless jwk
 
         ::JWT::JWK.import(jwk).keypair
       end

--- a/lib/jwt/jwk/key_finder.rb
+++ b/lib/jwt/jwk/key_finder.rb
@@ -15,7 +15,7 @@ module JWT
         jwk = resolve_key(kid)
 
         unless jwk
-          raise ::JWT::DecodeError, "No keys found in jwks" if jwks_keys.empty?
+          raise ::JWT::DecodeError, 'No keys found in jwks' if jwks_keys.empty?
           raise ::JWT::DecodeError, "Could not find public key for kid #{kid}"
         end
 

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -39,13 +39,18 @@ module JWT
 
       def self.import(jwk_data)
         imported_key = OpenSSL::PKey::RSA.new
+        jwk_n = jwk_data[:n] || jwk_data['n']
+        jwk_e = jwk_data[:e] || jwk_data['e']
+
+        raise JWT::JWKError, "Key format is invalid for RSA" unless jwk_n && jwk_e
+
         if imported_key.respond_to?(:set_key)
-          imported_key.set_key(OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:n]), BINARY),
-            OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:e]), BINARY),
+          imported_key.set_key(OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_n), BINARY),
+            OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_e), BINARY),
             nil)
         else
-          imported_key.n = OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:n]), BINARY)
-          imported_key.e = OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:e]), BINARY)
+          imported_key.n = OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_n), BINARY)
+          imported_key.e = OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_e), BINARY)
         end
         self.new(imported_key)
       end

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -42,7 +42,7 @@ module JWT
         jwk_n = jwk_data[:n] || jwk_data['n']
         jwk_e = jwk_data[:e] || jwk_data['e']
 
-        raise JWT::JWKError, "Key format is invalid for RSA" unless jwk_n && jwk_e
+        raise JWT::JWKError, 'Key format is invalid for RSA' unless jwk_n && jwk_e
 
         if imported_key.respond_to?(:set_key)
           imported_key.set_key(OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_n), BINARY),

--- a/spec/jwk/rsa_spec.rb
+++ b/spec/jwk/rsa_spec.rb
@@ -54,4 +54,34 @@ describe JWT::JWK::RSA do
       end
     end
   end
+
+  describe '.import' do
+    subject { described_class.import(params) }
+    let(:exported_key) { described_class.new(rsa_key).export }
+
+    context 'when keypair is imported with symbol keys' do
+      let(:params) { {e: exported_key[:e], n: exported_key[:n]} }
+      it 'returns a hash with the public parts of the key' do
+        expect(subject).to be_a described_class
+        expect(subject.private?).to eq false
+        expect(subject.export).to eq(exported_key)
+      end
+    end
+
+    context 'when keypair is imported with string keys from JSON' do
+      let(:params) { {'e' => exported_key[:e], 'n' => exported_key[:n]} }
+      it 'returns a hash with the public parts of the key' do
+        expect(subject).to be_a described_class
+        expect(subject.private?).to eq false
+        expect(subject.export).to eq(exported_key)
+      end
+    end
+
+    context 'when jwk_data is given without e and/or n' do
+      let(:params) { { kty: "RSA" } }
+      it 'raises an error' do
+        expect { subject }.to raise_error(JWT::JWKError, "Key format is invalid for RSA")
+      end
+    end
+  end
 end

--- a/spec/jwk_spec.rb
+++ b/spec/jwk_spec.rb
@@ -8,13 +8,22 @@ describe JWT::JWK do
 
   describe '.import' do
     let(:keypair) { rsa_key.public_key }
-    let(:params)  { described_class.new(keypair).export }
+    let(:exported_key) { described_class.new(keypair).export }
+    let(:params)  { exported_key }
 
     subject { described_class.import(params) }
 
     it 'creates a ::JWT::JWK::RSA instance' do
       expect(subject).to be_a ::JWT::JWK::RSA
-      expect(subject.export).to eq(params)
+      expect(subject.export).to eq(exported_key)
+    end
+
+    context 'parsed from JSON' do
+      let(:params)  { exported_key }
+      it 'creates a ::JWT::JWK::RSA instance from JSON parsed JWK' do
+        expect(subject).to be_a ::JWT::JWK::RSA
+        expect(subject.export).to eq(exported_key)
+      end
     end
 
     context 'when keytype is not supported' do
@@ -26,7 +35,7 @@ describe JWT::JWK do
     end
   end
 
-  describe '.to_jwk' do
+  describe '.new' do
     subject { described_class.new(keypair) }
 
     context 'when RSA key is given' do


### PR DESCRIPTION
When decoded JSON is passed to the JWK.import, there are difficult to diagnose failures that occur. 

Since the goal of JWKS is to support loading of json files, we should cleanly support string keys as that is the natural input to these methods.

This PR creates support for directly parsed JSON with string keys.
* No realistic performance decrease.
* Backwards compatibility is maintained by searching for symbol keys and then string keys.
* Improved error messaging that would have helped me find this issue more quickly.

I have copied below the spec output without the fixes I added. You can see from the failures that the errors are very difficult to understand when all that has happened is the keys were missed.

For instance, "could not find public key" is confusing because debugging shows a perfect match between your JWK and the JWT kid. It's simply the fact that the key is a string and this is not expected.

1) JWT.decode for JWK usecase when jwk keys are loaded from JSON with string keys decodes the token
     Failure/Error: raise ::JWT::DecodeError, "Could not find public key for kid #{kid}" unless jwk

```ruby
JWT::DecodeError:
  Could not find public key for kid 3240eb23aa4f72d26b1b1b534fee4c58c68a51af73b18acedd1e697a775a67fe
# ./lib/jwt/jwk/key_finder.rb:17:in `key_for'
# ./lib/jwt/decode.rb:37:in `verify_signature'
# ./lib/jwt/decode.rb:26:in `decode_segments'
# ./lib/jwt.rb:28:in `decode'
# ./spec/jwk/decode_with_jwk_spec.rb:71:in `block (4 levels) in <top (required)>'
```

  2) JWT::JWK::RSA.import when jwk_data is given without e and/or n raises an error
     Failure/Error: expect { subject }.to raise_error(JWT::JWKError, "Key format is invalid for RSA")

```ruby
expected JWT::JWKError with "Key format is invalid for RSA", got #<NoMethodError: undefined method `tr' for nil:NilClass> with backtrace:
# ./lib/jwt/jwk/rsa.rb:43:in `import'
# ./spec/jwk/rsa_spec.rb:59:in `block (3 levels) in <top (required)>'
# ./spec/jwk/rsa_spec.rb:83:in `block (5 levels) in <top (required)>'
# ./spec/jwk/rsa_spec.rb:83:in `block (4 levels) in <top (required)>'
# ./spec/jwk/rsa_spec.rb:83:in `block (4 levels) in <top (required)>'
```

  3) JWT::JWK::RSA.import when keypair is imported with string keys from JSON returns a hash with the public parts of the key

```ruby
Failure/Error:
  imported_key.set_key(OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:n]), BINARY),
    OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data[:e]), BINARY),
    nil)

NoMethodError:
  undefined method `tr' for nil:NilClass
# ./lib/jwt/jwk/rsa.rb:43:in `import'
# ./spec/jwk/rsa_spec.rb:59:in `block (3 levels) in <top (required)>'
# ./spec/jwk/rsa_spec.rb:74:in `block (4 levels) in <top (required)>'
```

Linking to #95 also because it is somewhat related to the string/symbol issue here.

EDIT:

The source of this problem could be tied back to the README example which uses `.export` instead of parsing an actual parsed JSON Web Key as the input to the key finder. We could update `export` to return string keys to make it more clear.