### PR TITLE
Improve support for Unsecured JWT

### DIFF
--- a/lib/jwt/algos/none.rb
+++ b/lib/jwt/algos/none.rb
@@ -1,0 +1,21 @@
+module JWT
+  module Algos
+    module None
+      # Unsecured JWT
+      module_function
+
+      SUPPORTED = %w[none].freeze
+
+      def sign(to_sign)
+        raise EncodeError, 'Signing key not supported for Unsecured JWT' if to_sign.key
+        ''
+      end
+
+      def verify(to_verify)
+        raise VerificationError, 'Signing key not supported for Unsecured JWT' if to_verify.public_key
+        raise VerificationError, 'Signature should be empty for Unsecured JWT' unless to_verify.signature == ''
+        true
+      end
+    end
+  end
+end

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -13,7 +13,7 @@ module JWT
       @jwt = jwt
       @key = key
       @options = options
-      @segments = jwt.split('.')
+      @segments = jwt.split('.', -1)
       @verify = verify
       @signature = ''
       @keyfinder = keyfinder
@@ -66,7 +66,6 @@ module JWT
 
     def validate_segment_count!
       return if segment_length == 3
-      return if !@verify && segment_length == 2 # If no verifying required, the signature is not needed
 
       raise(JWT::DecodeError, 'Not enough or too many segments')
     end

--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -52,8 +52,6 @@ module JWT
     end
 
     def encode_signature
-      return '' if @algorithm == ALG_NONE
-
       JWT::Base64.url_encode(JWT::Signature.sign(@algorithm, encoded_header_and_payload, @key))
     end
 

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -7,6 +7,7 @@ require 'jwt/algos/eddsa'
 require 'jwt/algos/ecdsa'
 require 'jwt/algos/rsa'
 require 'jwt/algos/ps'
+require 'jwt/algos/none'
 require 'jwt/algos/unsupported'
 begin
   require 'rbnacl'
@@ -25,6 +26,7 @@ module JWT
       Algos::Rsa,
       Algos::Eddsa,
       Algos::Ps,
+      Algos::None,
       Algos::Unsupported
     ].freeze
     ToSign = Struct.new(:algorithm, :msg, :key)


### PR DESCRIPTION
This allows for symmetric support of Unsecured JWT. It now works as any other algorithm for both encoding and decoding.

Fixes #323.

https://tools.ietf.org/html/rfc7519#section-6 allows for Unsecured JWT using "alg" value of "none". It does not forbid further processing of Unsecured JWT and thus claim verification still applies.

https://tools.ietf.org/html/rfc7518#section-3.6 requires the signature to be an empty string.

https://tools.ietf.org/html/rfc7518#section-3.6 and https://tools.ietf.org/html/rfc7518#section-8.5 forbid accepting Unsecured JWT unless explicitly allowed (this has already been addressed).

While not explicitly addressed by any RFC, based on common sense this commit explicitly forbids the use of any signing key for Unsecured JWT. As Unsecured JWT requires an empty signature and cannot possibly make use of a key, it should be considered an error to use a key together with algorithm value of "none". For an Unsecured JWT the signing key should be set to either false or nil.