### PR TITLE
Pin simplecov to < 0.18

### DIFF
--- a/ruby-jwt.gemspec
+++ b/ruby-jwt.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'simplecov', '< 0.18'
   spec.add_development_dependency 'simplecov-json'
   spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'codacy-coverage'


### PR DESCRIPTION
Something stopped being compatible with simplecov 0.18 so pinning the version for now.

Think we need to do something about all the coverage reporting dependencies, are they adding value?