### PR TITLE
Improve 'none' algorithm handling

### DIFF
--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -74,6 +74,7 @@ module JWT
     def validate_segment_count!
       return if segment_length == 3
       return if !@verify && segment_length == 2 # If no verifying required, the signature is not needed
+      return if segment_length == 2 && header['alg'] == 'none'
 
       raise(JWT::DecodeError, 'Not enough or too many segments')
     end
@@ -83,7 +84,7 @@ module JWT
     end
 
     def decode_crypto
-      @signature = JWT::Base64.url_decode(@segments[2])
+      @signature = JWT::Base64.url_decode(@segments[2] || '')
     end
 
     def header

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -38,6 +38,8 @@ module JWT
     end
 
     def verify(algorithm, key, signing_input, signature)
+      return true if algorithm == 'none'
+
       raise JWT::DecodeError, 'No verification key available' unless key
 
       algo = ALGOS.find do |alg|


### PR DESCRIPTION
when decoding a valid token with `algorithm: none`, unless explicitly
requesting not to verify the token, it could not be validated and raised
DecodeError with a message about insufficient segments.

This error message is misleading, because there are the correct number
of segments provided for that algorithm.

With this change, when a token with `algorithm: none` is provided:
* if the caller requests verification && does not specify `none` as an
  algorithm (default behaviour) it now raises `IncorrectAlgorithm`,
  which is a subclass of `DecodeError` to make the issue more clear.
  This is technically a minor change, but should not be breaking -
  it is returning a subclass, so the same rescues will still work. The
  message provided will be different.

* if the caller requests verification && specifies `none` as an allowed
  algorithm, it verifies the claims and decodes the token as it would
  for a valid, signed token.
  This is new behaviour supporting claims verification for 'none' which
  was not previously available and is only "accessed" through explicit
  settings

* if the caller explicitly requests no verification, the token is
  decoded without checking anything (no change in behaviour)