### PR TITLE
Add support for JWKs with HMAC key type.

### DIFF
--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'jwk/factory'
 require_relative 'jwk/rsa'
 require_relative 'jwk/hmac'
 require_relative 'jwk/key_finder'

--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'jwk/factory'
+require_relative 'jwk/key_abstract'
 require_relative 'jwk/rsa'
 require_relative 'jwk/hmac'
 require_relative 'jwk/key_finder'

--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 require_relative 'jwk/rsa'
+require_relative 'jwk/hmac'
 require_relative 'jwk/key_finder'
 
 module JWT
   module JWK
     MAPPINGS = {
       'RSA' => ::JWT::JWK::RSA,
-      OpenSSL::PKey::RSA => ::JWT::JWK::RSA
+      OpenSSL::PKey::RSA => ::JWT::JWK::RSA,
+      'oct' => ::JWT::JWK::HMAC,
+      String => ::JWT::JWK::HMAC
     }.freeze
 
     class << self

--- a/lib/jwt/jwk/factory.rb
+++ b/lib/jwt/jwk/factory.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module JWT
+  module JWK
+    class Factory
+      attr_reader :keypair
+      attr_reader :kid
+
+      def initialize(keypair, kid = nil)
+        @keypair = keypair
+        @kid = kid
+      end
+
+      def private?
+        raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+      end
+
+      def public_key
+        raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+      end
+
+      def export(options = {})
+        raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+      end
+
+      class << self
+        def import(jwk_data)
+          raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+        end
+      end
+    end
+  end
+end

--- a/lib/jwt/jwk/factory.rb
+++ b/lib/jwt/jwk/factory.rb
@@ -19,12 +19,12 @@ module JWT
         raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
       end
 
-      def export(options = {})
+      def export(_options = {})
         raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
       end
 
       class << self
-        def import(jwk_data)
+        def import(_jwk_data)
           raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
         end
       end

--- a/lib/jwt/jwk/factory.rb
+++ b/lib/jwt/jwk/factory.rb
@@ -3,8 +3,7 @@
 module JWT
   module JWK
     class Factory
-      attr_reader :keypair
-      attr_reader :kid
+      attr_reader :keypair, :kid
 
       def initialize(keypair, kid = nil)
         @keypair = keypair

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -19,13 +19,22 @@ module JWT
         true
       end
 
+      def public_key
+        nil
+      end
+
       # See https://tools.ietf.org/html/rfc7517#appendix-A.3
-      def export
-        {
+      def export(options = {})
+        ret = {
           kty: KTY,
-          k: keypair,
           kid: kid
         }
+
+        return ret unless private? && options[:include_private] == true
+
+        ret.merge(
+          k: keypair
+        )
       end
 
       private

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module JWT
+  module JWK
+    class HMAC
+      attr_reader :key
+      attr_reader :kid
+
+      KTY = 'oct'.freeze
+
+      def initialize(key, kid = nil)
+        raise ArgumentError, 'key must be of type String' unless key.is_a?(String)
+
+        @key = key
+        @kid = kid || generate_kid(@key)
+      end
+
+      def private?
+        true
+      end
+
+      # See https://tools.ietf.org/html/rfc7517#appendix-A.3
+      def export
+        {
+          kty: KTY,
+          k: key,
+          kid: kid
+        }
+      end
+
+      private
+
+      def generate_kid(hmac_key)
+        sequence = OpenSSL::ASN1::Sequence([OpenSSL::ASN1::UTF8String.new(hmac_key),
+                                            OpenSSL::ASN1::UTF8String.new(KTY)])
+        OpenSSL::Digest::SHA256.hexdigest(sequence.to_der)
+      end
+
+      class << self
+
+        def import(jwk_data)
+          jwk_k = jwk_data[:k] || jwk_data['k']
+          jwk_kid = jwk_data[:kid] || jwk_data['kid']
+
+          raise JWT::JWKError, 'Key format is invalid for HMAC' unless jwk_k
+
+          self.new(jwk_k, jwk_kid)
+        end
+      end
+    end
+  end
+end

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -3,16 +3,16 @@
 module JWT
   module JWK
     class HMAC
-      attr_reader :key
+      attr_reader :keypair
       attr_reader :kid
 
       KTY = 'oct'.freeze
 
-      def initialize(key, kid = nil)
-        raise ArgumentError, 'key must be of type String' unless key.is_a?(String)
+      def initialize(keypair, kid = nil)
+        raise ArgumentError, 'keypair must be of type String' unless keypair.is_a?(String)
 
-        @key = key
-        @kid = kid || generate_kid(@key)
+        @keypair = keypair
+        @kid = kid || generate_kid(@keypair)
       end
 
       def private?
@@ -23,7 +23,7 @@ module JWT
       def export
         {
           kty: KTY,
-          k: key,
+          k: keypair,
           kid: kid
         }
       end

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -37,7 +37,6 @@ module JWT
       end
 
       class << self
-
         def import(jwk_data)
           jwk_k = jwk_data[:k] || jwk_data['k']
           jwk_kid = jwk_data[:kid] || jwk_data['kid']

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -2,7 +2,7 @@
 
 module JWT
   module JWK
-    class HMAC < Factory
+    class HMAC < KeyAbstract
       KTY = 'oct'.freeze
 
       def initialize(keypair, kid = nil)

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -2,16 +2,13 @@
 
 module JWT
   module JWK
-    class HMAC
-      attr_reader :keypair
-      attr_reader :kid
-
+    class HMAC < Factory
       KTY = 'oct'.freeze
 
       def initialize(keypair, kid = nil)
         raise ArgumentError, 'keypair must be of type String' unless keypair.is_a?(String)
 
-        @keypair = keypair
+        super
         @kid = kid || generate_kid(@keypair)
       end
 

--- a/lib/jwt/jwk/key_abstract.rb
+++ b/lib/jwt/jwk/key_abstract.rb
@@ -2,7 +2,7 @@
 
 module JWT
   module JWK
-    class Factory
+    class KeyAbstract
       attr_reader :keypair, :kid
 
       def initialize(keypair, kid = nil)

--- a/spec/jwk/hmac_spec.rb
+++ b/spec/jwk/hmac_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'jwt'
+
+describe JWT::JWK::HMAC do
+  let(:hmac_key) { 'secret-key' }
+
+  describe '.new' do
+    subject { described_class.new(key) }
+
+    context 'when a secret key given' do
+      let(:key) { hmac_key }
+      it 'creates an instance of the class' do
+        expect(subject).to be_a described_class
+        expect(subject.private?).to eq true
+      end
+    end
+  end
+
+  describe '#export' do
+    let(:kid) { nil }
+    subject { described_class.new(key, kid).export }
+
+    context 'when key is exported' do
+      let(:key) { hmac_key }
+      it 'returns a hash with the key' do
+        expect(subject).to be_a Hash
+        expect(subject).to include(:kty, :kid, :k)
+      end
+    end
+  end
+
+  describe '.import' do
+    subject { described_class.import(params) }
+    let(:exported_key) { described_class.new(key).export }
+
+    context 'when secret key is given' do
+      let(:key) { hmac_key }
+      let(:params) { exported_key }
+
+      it 'returns a key' do
+        expect(subject).to be_a described_class
+        expect(subject.export).to eq(exported_key)
+      end
+
+      context 'with a custom "kid" value' do
+        let(:exported_key) {
+          super().merge(kid: 'custom_key_identifier')
+        }
+        it 'imports that "kid" value' do
+          expect(subject.kid).to eq('custom_key_identifier')
+        end
+      end
+    end
+  end
+end

--- a/spec/jwk/hmac_spec.rb
+++ b/spec/jwk/hmac_spec.rb
@@ -20,10 +20,19 @@ describe JWT::JWK::HMAC do
 
   describe '#export' do
     let(:kid) { nil }
-    subject { described_class.new(key, kid).export }
 
     context 'when key is exported' do
       let(:key) { hmac_key }
+      subject { described_class.new(key, kid).export }
+      it 'returns a hash with the key' do
+        expect(subject).to be_a Hash
+        expect(subject).to include(:kty, :kid)
+      end
+    end
+
+    context 'when key is exported with private key' do
+      let(:key) { hmac_key }
+      subject { described_class.new(key, kid).export(include_private: true) }
       it 'returns a hash with the key' do
         expect(subject).to be_a Hash
         expect(subject).to include(:kty, :kid, :k)
@@ -33,7 +42,7 @@ describe JWT::JWK::HMAC do
 
   describe '.import' do
     subject { described_class.import(params) }
-    let(:exported_key) { described_class.new(key).export }
+    let(:exported_key) { described_class.new(key).export(include_private: true) }
 
     context 'when secret key is given' do
       let(:key) { hmac_key }
@@ -41,7 +50,7 @@ describe JWT::JWK::HMAC do
 
       it 'returns a key' do
         expect(subject).to be_a described_class
-        expect(subject.export).to eq(exported_key)
+        expect(subject.export(include_private: true)).to eq(exported_key)
       end
 
       context 'with a custom "kid" value' do

--- a/spec/jwk_spec.rb
+++ b/spec/jwk_spec.rb
@@ -43,11 +43,9 @@ describe JWT::JWK do
       it { is_expected.to be_a ::JWT::JWK::RSA }
     end
 
-    context 'when unsupported key is given' do
-      let(:keypair) { 'key' }
-      it 'raises an error' do
-        expect { subject }.to raise_error(::JWT::JWKError, 'Cannot create JWK from a String')
-      end
+    context 'when secret key is given' do
+      let(:keypair) { 'secret-key' }
+      it { is_expected.to be_a ::JWT::JWK::HMAC }
     end
   end
 end


### PR DESCRIPTION
Adds support for JWKs with "kty" value "oct" (HMAC).

For additional details on these JWKs and their contents, see https://tools.ietf.org/html/rfc7517#appendix-A.3.

This implementation of `JWT::JWK::HMAC` adheres closely to the pattern set by `JWT::JWK::RSA` and PR #371 of @richardlarocque `JWT::JWK::EC`. It keeps the same coding style and method names.

Like specified in the RFC:

- It emits the secret key ("k") value when exporting JWKs.
- An import followed by an export preserve the "kid" value.
- Instance method `private?` returns always true because "k" is always exported.