### PR TITLE
Disable Rails cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,9 +5,6 @@ AllCops:
     - 'config/**/*'
     - 'script/**/*'
 
-Rails:
-  Enabled: true
-
 Style/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 


### PR DESCRIPTION
Having the Rails Cops enabled gives false warnings about Rails specific syntax. For example it suggest using `delegate` even if the gem does not use [activesupport](https://guides.rubyonrails.org/active_support_core_extensions.html#delegate) that provides this functionality.