### PR TITLE
Support JWKs for pre 2.3 rubies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,12 @@ jobs:
           - gemfiles/rbnacl.gemfile
         experimental: [false]
         include:
-#          - ruby: 2.1
-#            experimental: true
-#          - ruby: 2.2
-#            experimental: true
+          - ruby: 2.1
+            gemfile: 'gemfiles/rbnacl.gemfile'
+            experimental: false
+          - ruby: 2.2
+            gemfile: 'gemfiles/rbnacl.gemfile'
+            experimental: false
           - ruby: 2.7
             coverage: "true"
             gemfile: 'gemfiles/rbnacl.gemfile'

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -70,11 +70,11 @@ module JWT
       end
 
       def encode_octets(octets)
-        ::Base64.urlsafe_encode64(octets, padding: false)
+        ::JWT::Base64.url_encode(octets)
       end
 
       def encode_open_ssl_bn(key_part)
-        ::Base64.urlsafe_encode64(key_part.to_s(BINARY), padding: false)
+        ::JWT::Base64.url_encode(key_part.to_s(BINARY))
       end
 
       class << self
@@ -136,11 +136,11 @@ module JWT
         end
 
         def decode_octets(jwk_data)
-          ::Base64.urlsafe_decode64(jwk_data)
+          ::JWT::Base64.url_decode(jwk_data)
         end
 
         def decode_open_ssl_bn(jwk_data)
-          OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data), BINARY)
+          OpenSSL::BN.new(::JWT::Base64.url_decode(jwk_data), BINARY)
         end
       end
     end

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -54,7 +54,7 @@ module JWT
       end
 
       def encode_open_ssl_bn(key_part)
-        ::Base64.urlsafe_encode64(key_part.to_s(BINARY), padding: false)
+        ::JWT::Base64.url_encode(key_part.to_s(BINARY))
       end
 
       class << self
@@ -107,7 +107,7 @@ module JWT
         def decode_open_ssl_bn(jwk_data)
           return nil unless jwk_data
 
-          OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data), BINARY)
+          OpenSSL::BN.new(::JWT::Base64.url_decode(jwk_data), BINARY)
         end
       end
     end


### PR DESCRIPTION
This should fix the issue in #361. Even if the Rubies are EOL and stone-age we should probably still support them while the gemspec claims to support `>= 2.1`

Part of the problem is that the CI has not been executed for pre 2.3 versions in a while, was thinking we could maybe add the older rubies to the test matrix in #381 before we remove the support completely in the next major version of this gem.



