### PR TITLE
Make JWT::JWK::EC compatible with Ruby 2.3

### DIFF
--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -4,7 +4,7 @@ module JWT
   module JWK
     class EC < KeyBase
       extend Forwardable
-      def_delegators :@keypair, :private?, :public_key
+      def_delegators :@keypair, :public_key
 
       KTY    = 'EC'.freeze
       KTYS   = [KTY, OpenSSL::PKey::EC].freeze
@@ -15,6 +15,10 @@ module JWT
 
         kid ||= generate_kid(keypair)
         super(keypair, kid)
+      end
+
+      def private?
+        @keypair.private_key?
       end
 
       def export(options = {})

--- a/spec/jwk/ec_spec.rb
+++ b/spec/jwk/ec_spec.rb
@@ -4,7 +4,7 @@ require_relative '../spec_helper'
 require 'jwt'
 
 describe JWT::JWK::EC do
-  let(:ec_key) { OpenSSL::PKey::EC.new("secp384r1").generate_key! }
+  let(:ec_key) { OpenSSL::PKey::EC.new("secp384r1").generate_key }
 
   describe '.new' do
     subject { described_class.new(keypair) }
@@ -82,7 +82,7 @@ describe JWT::JWK::EC do
     ['P-256', 'P-384', 'P-521'].each do |crv|
       context "when crv=#{crv}" do
         let(:openssl_curve) { JWT::JWK::EC.to_openssl_curve(crv) }
-        let(:ec_key) { OpenSSL::PKey::EC.new(openssl_curve).generate_key! }
+        let(:ec_key) { OpenSSL::PKey::EC.new(openssl_curve).generate_key }
 
         context 'when keypair is private' do
           let(:include_private) { true }

--- a/spec/jwk_spec.rb
+++ b/spec/jwk_spec.rb
@@ -5,7 +5,7 @@ require 'jwt'
 
 describe JWT::JWK do
   let(:rsa_key) { OpenSSL::PKey::RSA.new(2048) }
-  let(:ec_key) { OpenSSL::PKey::EC.new("secp384r1").generate_key! }
+  let(:ec_key) { OpenSSL::PKey::EC.new("secp384r1").generate_key }
 
   describe '.import' do
     let(:keypair) { rsa_key.public_key }


### PR DESCRIPTION
Seems that the `OpenSSL::PKey::EC#generate_key!` method is not available in Ruby 2.3 without installing the openssl gem.

This other PR that is making the CIactually test the supported Rubies and combinations revealed that:
https://travis-ci.org/github/jwt/ruby-jwt/jobs/747060754