### PR TITLE
JWK OKP support

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,7 +59,7 @@ Metrics/AbcSize:
   Max: 20
 
 Metrics/ClassLength:
-  Max: 100
+  Max: 110
 
 Metrics/ModuleLength:
   Max: 100

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,10 @@ AllCops:
     - 'config/**/*'
     - 'script/**/*'
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 Style/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'rbnacl'
-gem 'rubocop', '<0.58'
+gem 'rubocop', '~> 0.52.1'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem "rbnacl"
-gem "rubocop", '<0.58'
+gem 'rbnacl'
+gem 'rubocop', '<0.58'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem "rbnacl"
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 gem "rbnacl"
-
+gem "rubocop", '<0.58'
 gemspec

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ JWK is a JSON structure representing a cryptographic key. Currently only support
 jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048))
 payload, headers = { data: 'data' }, { kid: jwk.kid }
 
-token = JWT.encode(payload, jwk.keypair, 'RS512', headers)
+token = JWT.encode(payload, jwk.signing_key, 'RS512', headers)
 
 # The jwk loader would fetch the set of JWKs from a trusted source
 jwk_loader = ->(options) do

--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -45,6 +45,7 @@ module JWT
   end
 end
 
+require_relative 'jwk/thumbprint'
 require_relative 'jwk/key_base'
 require_relative 'jwk/ec'
 require_relative 'jwk/rsa'

--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -14,10 +14,10 @@ module JWT
         end.import(jwk_data)
       end
 
-      def create_from(keypair)
-        mappings.fetch(keypair.class) do |klass|
+      def create_from(key)
+        mappings.fetch(key.class) do |klass|
           raise JWT::JWKError, "Cannot create JWK from a #{klass.name}"
-        end.new(keypair)
+        end.new(key)
       end
 
       def classes

--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -49,3 +49,4 @@ require_relative 'jwk/key_base'
 require_relative 'jwk/ec'
 require_relative 'jwk/rsa'
 require_relative 'jwk/hmac'
+require_relative 'jwk/okp' if defined?(RbNaCl)

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -5,16 +5,17 @@ module JWT
     class EC < KeyBase
       extend Forwardable
       def_delegators :@keypair, :public_key
-
+      attr_reader :keypair
+      
       KTY    = 'EC'.freeze
       KTYS   = [KTY, OpenSSL::PKey::EC].freeze
       BINARY = 2
-
+      
       def initialize(keypair, kid = nil)
         raise ArgumentError, 'keypair must be of type OpenSSL::PKey::EC' unless keypair.is_a?(OpenSSL::PKey::EC)
 
-        kid ||= generate_kid(keypair)
-        super(keypair, kid)
+        @kid = kid
+        @keypair = keypair
       end
 
       def private?
@@ -36,6 +37,10 @@ module JWT
         return exported_hash unless private? && options[:include_private] == true
 
         append_private_parts(exported_hash)
+      end
+
+      def kid
+        @kid ||= generate_kid(keypair)
       end
 
       private

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -21,15 +21,18 @@ module JWT
         @keypair.private_key?
       end
 
-      def export(options = {})
+      def members
         crv, x_octets, y_octets = keypair_components(keypair)
-        exported_hash = {
+        {
           kty: KTY,
           crv: crv,
           x: encode_octets(x_octets),
-          y: encode_octets(y_octets),
-          kid: kid
+          y: encode_octets(y_octets)
         }
+      end
+
+      def export(options = {})
+        exported_hash = members.merge(kid: kid)
         return exported_hash unless private? && options[:include_private] == true
 
         append_private_parts(exported_hash)

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -12,7 +12,7 @@ module JWT
       def initialize(keypair, kid = nil)
         raise ArgumentError, 'keypair must be of type OpenSSL::PKey::EC' unless keypair.is_a?(OpenSSL::PKey::EC)
         @verify_key = keypair.public_key
-        @signing_key = keypair if keypair.private?
+        @signing_key = keypair if keypair.private_key?
         @kid = kid
       end
 

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -6,11 +6,11 @@ module JWT
       extend Forwardable
       def_delegators :@keypair, :public_key
       attr_reader :keypair
-      
+
       KTY    = 'EC'.freeze
       KTYS   = [KTY, OpenSSL::PKey::EC].freeze
       BINARY = 2
-      
+
       def initialize(keypair, kid = nil)
         raise ArgumentError, 'keypair must be of type OpenSSL::PKey::EC' unless keypair.is_a?(OpenSSL::PKey::EC)
 

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -11,8 +11,8 @@ module JWT
 
       def initialize(keypair, kid = nil)
         raise ArgumentError, 'keypair must be of type OpenSSL::PKey::EC' unless keypair.is_a?(OpenSSL::PKey::EC)
-        @verify_key = keypair.public_key
-        @signing_key = keypair if keypair.private_key?
+        @verify_key  = keypair.public_key
+        @signing_key = keypair.private_key if keypair.private_key?
         @kid = kid
       end
 
@@ -48,10 +48,8 @@ module JWT
       end
 
       def append_private_parts(the_hash)
-        octets = keypair.private_key.to_bn.to_s(BINARY)
-        the_hash.merge(
-          d: encode_octets(octets)
-        )
+        octets = signing_key.to_bn.to_s(BINARY)
+        the_hash.merge(d: encode_octets(octets))
       end
 
       def keypair_components(verify_key)

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -6,10 +6,14 @@ module JWT
       KTY = 'oct'.freeze
       KTYS = [KTY, String].freeze
 
-      attr_reader :keypair
-      def initialize(keypair, kid = nil)
-        raise ArgumentError, 'keypair must be of type String' unless keypair.is_a?(String)
-        @keypair = keypair
+      attr_reader :secret
+
+      alias verify_key secret
+      alias signing_key secret
+
+      def initialize(secret, kid = nil)
+        raise ArgumentError, 'secret must be of type String' unless secret.is_a?(String)
+        @secret = secret
         @kid = kid
       end
 
@@ -53,9 +57,7 @@ module JWT
       private
 
       def generate_kid
-        sequence = OpenSSL::ASN1::Sequence([OpenSSL::ASN1::UTF8String.new(keypair),
-                                            OpenSSL::ASN1::UTF8String.new(KTY)])
-        OpenSSL::Digest::SHA256.hexdigest(sequence.to_der)
+        Thumbprint.new(self).to_s
       end
 
       class << self

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -6,11 +6,11 @@ module JWT
       KTY = 'oct'.freeze
       KTYS = [KTY, String].freeze
 
+      attr_reader :keypair
       def initialize(keypair, kid = nil)
         raise ArgumentError, 'keypair must be of type String' unless keypair.is_a?(String)
-
-        super
-        @kid = kid || generate_kid
+        @keypair = keypair
+        @kid = kid
       end
 
       def private?
@@ -19,6 +19,14 @@ module JWT
 
       def public_key
         nil
+      end
+
+      def private_key
+        keypair
+      end
+
+      def kid
+        @kid ||= generate_kid
       end
 
       def members

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -21,6 +21,13 @@ module JWT
         nil
       end
 
+      def members
+        {
+          kty: KTY,
+          k: keypair
+        }
+      end
+
       # See https://tools.ietf.org/html/rfc7517#appendix-A.3
       def export(options = {})
         exported_hash = {

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -25,10 +25,6 @@ module JWT
         nil
       end
 
-      def private_key
-        keypair
-      end
-
       def kid
         @kid ||= generate_kid
       end
@@ -36,7 +32,7 @@ module JWT
       def members
         {
           kty: KTY,
-          k: keypair
+          k: signing_key
         }
       end
 
@@ -50,7 +46,7 @@ module JWT
         return exported_hash unless private? && options[:include_private] == true
 
         exported_hash.merge(
-          k: keypair
+          k: signing_key
         )
       end
 

--- a/lib/jwt/jwk/key_base.rb
+++ b/lib/jwt/jwk/key_base.rb
@@ -6,18 +6,6 @@ module JWT
       def self.inherited(klass)
         ::JWT::JWK.classes << klass
       end
-
-      def keypair
-        signing_key || verify_key
-      end
-
-      def public_key
-        verify_key
-      end
-
-      def private_key
-        signing_key
-      end
     end
   end
 end

--- a/lib/jwt/jwk/key_base.rb
+++ b/lib/jwt/jwk/key_base.rb
@@ -6,6 +6,18 @@ module JWT
       def self.inherited(klass)
         ::JWT::JWK.classes << klass
       end
+
+      def keypair
+        signing_key || verify_key
+      end
+
+      def public_key
+        verify_key
+      end
+
+      def private_key
+        signing_key
+      end
     end
   end
 end

--- a/lib/jwt/jwk/key_base.rb
+++ b/lib/jwt/jwk/key_base.rb
@@ -3,13 +3,6 @@
 module JWT
   module JWK
     class KeyBase
-      attr_reader :keypair, :kid
-
-      def initialize(keypair, kid = nil)
-        @keypair = keypair
-        @kid     = kid
-      end
-
       def self.inherited(klass)
         ::JWT::JWK.classes << klass
       end

--- a/lib/jwt/jwk/key_finder.rb
+++ b/lib/jwt/jwk/key_finder.rb
@@ -17,7 +17,7 @@ module JWT
         raise ::JWT::DecodeError, 'No keys found in jwks' if jwks_keys.empty?
         raise ::JWT::DecodeError, "Could not find public key for kid #{kid}" unless jwk
 
-        ::JWT::JWK.import(jwk).keypair
+        ::JWT::JWK.import(jwk).verify_key
       end
 
       private

--- a/lib/jwt/jwk/okp.rb
+++ b/lib/jwt/jwk/okp.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module JWT
+  module JWK
+    # https://tools.ietf.org/html/rfc8037
+    class OKP < KeyBase
+      BINARY = 2
+      KTY    = 'OKP'.freeze
+      KTYS   = [KTY, RbNaCl::Signatures::Ed25519::SigningKey, RbNaCl::Signatures::Ed25519::VerifyKey]
+
+      attr_reader :kid
+
+      def initialize(key, kid = nil)
+        case key
+        when RbNaCl::Signatures::Ed25519::SigningKey
+          @signing_key = key
+          @verify_key = key.verify_key
+        when RbNaCl::Signatures::Ed25519::VerifyKey
+          @verify_key = key
+        else
+          raise ArgumentError, 'key must be of type RbNaCl::Signatures::Ed25519::SigningKey or RbNaCl::Signatures::Ed25519::VerifyKey' 
+        end
+
+        @kid = kid
+        
+        super
+      end
+    end
+  end
+end

--- a/lib/jwt/jwk/okp.rb
+++ b/lib/jwt/jwk/okp.rb
@@ -28,6 +28,10 @@ module JWT
         super
       end
 
+      def keypair
+        @verify_key
+      end
+
       def public_key
         @verify_key
       end

--- a/lib/jwt/jwk/okp.rb
+++ b/lib/jwt/jwk/okp.rb
@@ -28,16 +28,16 @@ module JWT
         super
       end
 
+      def public_key
+        @verify_key
+      end
+
       def private?
         !@signing_key.nil?
       end
 
       def kid
         @kid ||= generate_kid
-      end
-
-      def generate_kid
-        Thumbprint.new(self).to_s
       end
 
       def members
@@ -56,6 +56,10 @@ module JWT
       end
 
       private
+
+      def generate_kid
+        Thumbprint.new(self).to_s
+      end
 
       def append_private_parts(the_hash)
         the_hash.merge(

--- a/lib/jwt/jwk/okp.rb
+++ b/lib/jwt/jwk/okp.rb
@@ -6,7 +6,9 @@ module JWT
     class OKP < KeyBase
       BINARY = 2
       KTY    = 'OKP'.freeze
-      KTYS   = [KTY, RbNaCl::Signatures::Ed25519::SigningKey, RbNaCl::Signatures::Ed25519::VerifyKey]
+      KTYS   = [KTY, 
+               RbNaCl::Signatures::Ed25519::SigningKey,
+               RbNaCl::Signatures::Ed25519::VerifyKey]
 
       attr_reader :kid
 
@@ -24,6 +26,13 @@ module JWT
         @kid = kid
         
         super
+      end
+
+      def private?
+        !@signing_key.nil?
+      end
+
+      def kid
       end
     end
   end

--- a/lib/jwt/jwk/okp.rb
+++ b/lib/jwt/jwk/okp.rb
@@ -77,10 +77,10 @@ module JWT
           attributes = jwk_attributes(jwk_data, :x, :d, :kid)
 
           key = if attributes[:d]
-                  RbNaCl::Signatures::Ed25519::SigningKey.new(::JWT::Base64.url_decode(attributes[:d]))
-                else
-                  RbNaCl::Signatures::Ed25519::VerifyKey.new(::JWT::Base64.url_decode(attributes[:x]))
-                end
+            RbNaCl::Signatures::Ed25519::SigningKey.new(::JWT::Base64.url_decode(attributes[:d]))
+          else
+            RbNaCl::Signatures::Ed25519::VerifyKey.new(::JWT::Base64.url_decode(attributes[:x]))
+          end
 
           new(key, attributes[:kid])
         end

--- a/lib/jwt/jwk/okp.rb
+++ b/lib/jwt/jwk/okp.rb
@@ -11,6 +11,8 @@ module JWT
 
       ED25519 = 'Ed25519'.freeze
 
+      attr_reader :verify_key, :signing_key
+
       def initialize(key, kid = nil)
         case key
         when RbNaCl::Signatures::Ed25519::SigningKey
@@ -19,26 +21,15 @@ module JWT
         when RbNaCl::Signatures::Ed25519::VerifyKey
           @verify_key = key
         else
-          raise ArgumentError, 'key must be of type RbNaCl::Signatures::Ed25519::SigningKey or RbNaCl::Signatures::Ed25519::VerifyKey'
+          raise ArgumentError, 'key must be of type RbNaCl::Signatures::Ed25519::SigningKey or ' \
+                               'RbNaCl::Signatures::Ed25519::VerifyKey'
         end
 
         @kid = kid
       end
 
-      def keypair
-        @verify_key
-      end
-
-      def private_key
-        @signing_key
-      end
-
-      def public_key
-        @verify_key
-      end
-
       def private?
-        !@signing_key.nil?
+        !signing_key.nil?
       end
 
       def kid

--- a/lib/jwt/jwk/okp.rb
+++ b/lib/jwt/jwk/okp.rb
@@ -6,13 +6,11 @@ module JWT
     class OKP < KeyBase
       BINARY = 2
       KTY    = 'OKP'.freeze
-      KTYS   = [KTY, 
-               RbNaCl::Signatures::Ed25519::SigningKey,
-               RbNaCl::Signatures::Ed25519::VerifyKey]
+      KTYS   = [KTY,
+                RbNaCl::Signatures::Ed25519::SigningKey,
+                RbNaCl::Signatures::Ed25519::VerifyKey].freeze
 
       ED25519 = 'Ed25519'.freeze
-
-      attr_reader :kid
 
       def initialize(key, kid = nil)
         case key
@@ -22,11 +20,11 @@ module JWT
         when RbNaCl::Signatures::Ed25519::VerifyKey
           @verify_key = key
         else
-          raise ArgumentError, 'key must be of type RbNaCl::Signatures::Ed25519::SigningKey or RbNaCl::Signatures::Ed25519::VerifyKey' 
+          raise ArgumentError, 'key must be of type RbNaCl::Signatures::Ed25519::SigningKey or RbNaCl::Signatures::Ed25519::VerifyKey'
         end
 
         @kid = kid
-        
+
         super
       end
 
@@ -46,7 +44,7 @@ module JWT
         {
           kty: KTY,
           crv: ED25519,
-          x: ::JWT::Base64.url_encode(@verify_key.to_bytes),
+          x: ::JWT::Base64.url_encode(@verify_key.to_bytes)
         }
       end
 

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -8,9 +8,12 @@ module JWT
       KTYS   = [KTY, OpenSSL::PKey::RSA].freeze
       RSA_KEY_ELEMENTS = %i[n e d p q dp dq qi].freeze
 
+      attr_reader :keypair
+
       def initialize(keypair, kid = nil)
         raise ArgumentError, 'keypair must be of type OpenSSL::PKey::RSA' unless keypair.is_a?(OpenSSL::PKey::RSA)
-        super(keypair, kid || generate_kid(keypair.public_key))
+        @keypair = keypair
+        @kid = kid
       end
 
       def private?
@@ -19,6 +22,15 @@ module JWT
 
       def public_key
         keypair.public_key
+      end
+  
+      def private_key
+        return nil unless private?
+        @keypair
+      end
+
+      def kid
+        @kid ||= generate_kid(keypair.public_key)
       end
 
       def members
@@ -36,6 +48,8 @@ module JWT
 
         append_private_parts(exported_hash)
       end
+
+
 
       private
 

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -17,6 +17,21 @@ module JWT
         @kid = kid
       end
 
+      def keypair
+        warn('[DEPRECATION] The ::JWT::JWK::RSA#keypair method is deprecated and going to be removed in future versions')
+        signing_key || verify_key
+      end
+
+      def public_key
+        warn('[DEPRECATION] The ::JWT::JWK::RSA#public_key method is deprecated and going to be removed in future versions')
+        verify_key
+      end
+
+      def private_key
+        warn('[DEPRECATION] The ::JWT::JWK::RSA#private_key method is deprecated and going to be removed in future versions')
+        signing_key
+      end
+
       def private?
         !signing_key.nil?
       end

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -21,13 +21,16 @@ module JWT
         keypair.public_key
       end
 
-      def export(options = {})
-        exported_hash = {
+      def members
+        {
           kty: KTY,
           n: encode_open_ssl_bn(public_key.n),
-          e: encode_open_ssl_bn(public_key.e),
-          kid: kid
+          e: encode_open_ssl_bn(public_key.e)
         }
+      end
+
+      def export(options = {})
+        exported_hash = members.merge(kid: kid)
 
         return exported_hash unless private? && options[:include_private] == true
 

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -23,7 +23,7 @@ module JWT
       def public_key
         keypair.public_key
       end
-  
+
       def private_key
         return nil unless private?
         @keypair
@@ -48,8 +48,6 @@ module JWT
 
         append_private_parts(exported_hash)
       end
-
-
 
       private
 

--- a/lib/jwt/jwk/thumbprint.rb
+++ b/lib/jwt/jwk/thumbprint.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module JWT
+  module JWK
+    # https://tools.ietf.org/html/rfc7638
+    class Thumbprint
+      attr_reader :jwk
+      def initialize(jwk)
+        @jwk = jwk
+      end
+
+      def to_s
+        JWT::Base64.url_encode(
+          Digest::SHA256.digest(
+            JSON.generate(
+              jwk.members.sort.to_h
+            )
+          )
+        )
+      end
+    end
+  end
+end

--- a/lib/jwt/version.rb
+++ b/lib/jwt/version.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 # Moments version builder module
@@ -16,7 +15,7 @@ module JWT
     # tiny version
     TINY  = 0
     # alpha, beta, etc. tag
-    PRE   = 'dev'
+    PRE   = 'dev'.freeze
 
     # Build version string
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/spec/jwk/decode_with_jwk_spec.rb
+++ b/spec/jwk/decode_with_jwk_spec.rb
@@ -8,7 +8,7 @@ describe JWT do
     let(:token_payload) { {'data' => 'something'} }
     let(:token_headers) { { kid: jwk.kid } }
     let(:algorithm)     { 'RS512' }
-    let(:signed_token)  { described_class.encode(token_payload, jwk.private_key, algorithm, token_headers) }
+    let(:signed_token)  { described_class.encode(token_payload, jwk.signing_key, algorithm, token_headers) }
 
     context 'when JWK features are used manually' do
       it 'is able to decode the token' do

--- a/spec/jwk/decode_with_jwk_spec.rb
+++ b/spec/jwk/decode_with_jwk_spec.rb
@@ -76,7 +76,7 @@ describe JWT do
 
     context 'when jwk keys are loaded from JSON with string keys' do
       it 'decodes the token' do
-        key_loader = ->(options) { JSON.parse(JSON.generate(public_jwks)) }
+        key_loader = ->(_options) { JSON.parse(JSON.generate(public_jwks)) }
         payload, _header = described_class.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: key_loader})
         expect(payload).to eq(token_payload)
       end

--- a/spec/jwk/decode_with_jwk_spec.rb
+++ b/spec/jwk/decode_with_jwk_spec.rb
@@ -80,14 +80,16 @@ describe JWT do
       end
     end
 
-    context 'when OKP keys are used' do
-      let(:keypair) { RbNaCl::Signatures::Ed25519::SigningKey.new(SecureRandom.hex) }
-      let(:algorithm) { 'ED25519' }
-      it 'decodes the token' do
-        key_loader = ->(_options) { JSON.parse(JSON.generate(public_jwks)) }
-        payload, _header = described_class.decode(signed_token, nil, true, { algorithms: [algorithm], jwks: key_loader})
-        expect(payload).to eq(token_payload)
+    if defined?(RbNaCl)
+      context 'when OKP keys are used' do
+        let(:keypair) { RbNaCl::Signatures::Ed25519::SigningKey.new(SecureRandom.hex) }
+        let(:algorithm) { 'ED25519' }
+        it 'decodes the token' do
+          key_loader = ->(_options) { JSON.parse(JSON.generate(public_jwks)) }
+          payload, _header = described_class.decode(signed_token, nil, true, { algorithms: [algorithm], jwks: key_loader})
+          expect(payload).to eq(token_payload)
+        end
       end
-    end if defined?(RbNaCl)
+    end
   end
 end

--- a/spec/jwk/ec_spec.rb
+++ b/spec/jwk/ec_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../spec_helper'
-require 'jwt'
-
 describe JWT::JWK::EC do
   let(:ec_key) { OpenSSL::PKey::EC.new("secp384r1").generate_key }
 

--- a/spec/jwk/ec_spec.rb
+++ b/spec/jwk/ec_spec.rb
@@ -94,7 +94,7 @@ describe JWT::JWK::EC do
             expect(subject).to be_a described_class
 
             # Regular export returns only the non-private parts.
-            public_only = exported_key.select{ |k, v| k != :d }
+            public_only = exported_key.reject { |k, _v| k == :d }
             expect(subject.export).to eq(public_only)
 
             # Private export returns the original input.

--- a/spec/jwk/ec_spec.rb
+++ b/spec/jwk/ec_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe JWT::JWK::EC do
-  let(:ec_key) { OpenSSL::PKey::EC.new("secp384r1").generate_key }
+  let(:ec_key) { OpenSSL::PKey::EC.new('secp384r1').generate_key }
 
   describe '.new' do
     subject { described_class.new(keypair) }

--- a/spec/jwk/hmac_spec.rb
+++ b/spec/jwk/hmac_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../spec_helper'
-require 'jwt'
-
 describe JWT::JWK::HMAC do
   let(:hmac_key) { 'secret-key' }
 

--- a/spec/jwk/okp_spec.rb
+++ b/spec/jwk/okp_spec.rb
@@ -6,22 +6,36 @@ require 'jwt'
 describe JWT::JWK::OKP do
   let(:private_key) { RbNaCl::Signatures::Ed25519::SigningKey.new(SecureRandom.hex) }
   let(:public_key)  { private_key.verify_key }
+  let(:key) { nil }
+ 
+  subject(:instance) { described_class.new(key) }
 
   describe '.new' do
     context 'when private key is given' do
-      it 'creates a new instance' do
-        expect(described_class.new(private_key)).to be_a(described_class)
-      end
+      let(:key) { private_key }
+      it { is_expected.to be_a(described_class) }
     end
     context 'when public key is given' do
-      it 'creates a new instance' do
-        expect(described_class.new(public_key)).to be_a(described_class)
-      end
+      let(:key) { public_key }
+      it { is_expected.to be_a(described_class) }
     end
     context 'when something else than a public or private key is given' do
+      let(:key) { OpenSSL::PKey::RSA.new(2048) }
       it 'raises an ArgumentError' do
-        expect { described_class.new(OpenSSL::PKey::RSA.new(2048)) }.to raise_error(ArgumentError)
+        expect { instance }.to raise_error(ArgumentError)
       end
+    end
+  end
+
+  describe '#private?' do
+    subject { instance.private? }
+    context 'when private key is given' do
+      let(:key) { private_key }
+      it { is_expected.to eq(true) }
+    end
+    context 'when public key is given' do
+      let(:key) { public_key }
+      it { is_expected.to eq(false) }
     end
   end
 end if defined?(RbNaCl)

--- a/spec/jwk/okp_spec.rb
+++ b/spec/jwk/okp_spec.rb
@@ -3,52 +3,66 @@
 require_relative '../spec_helper'
 require 'jwt'
 
-describe JWT::JWK::OKP do
-  let(:private_key) { RbNaCl::Signatures::Ed25519::SigningKey.new(SecureRandom.hex) }
-  let(:public_key)  { private_key.verify_key }
-  let(:key) { nil }
- 
-  subject(:instance) { described_class.new(key) }
+if defined?(RbNaCl)
+  describe JWT::JWK::OKP do
+    let(:private_key) { RbNaCl::Signatures::Ed25519::SigningKey.new(SecureRandom.hex) }
+    let(:public_key)  { private_key.verify_key }
+    let(:key) { nil }
 
-  describe '.new' do
-    context 'when private key is given' do
-      let(:key) { private_key }
-      it { is_expected.to be_a(described_class) }
+    subject(:instance) { described_class.new(key) }
+
+    describe '.new' do
+      context 'when private key is given' do
+        let(:key) { private_key }
+        it { is_expected.to be_a(described_class) }
+      end
+      context 'when public key is given' do
+        let(:key) { public_key }
+        it { is_expected.to be_a(described_class) }
+      end
+      context 'when something else than a public or private key is given' do
+        let(:key) { OpenSSL::PKey::RSA.new(2048) }
+        it 'raises an ArgumentError' do
+          expect { instance }.to raise_error(ArgumentError)
+        end
+      end
     end
-    context 'when public key is given' do
-      let(:key) { public_key }
-      it { is_expected.to be_a(described_class) }
+
+    describe '#private?' do
+      subject { instance.private? }
+      context 'when private key is given' do
+        let(:key) { private_key }
+        it { is_expected.to eq(true) }
+      end
+      context 'when public key is given' do
+        let(:key) { public_key }
+        it { is_expected.to eq(false) }
+      end
     end
-    context 'when something else than a public or private key is given' do
-      let(:key) { OpenSSL::PKey::RSA.new(2048) }
-      it 'raises an ArgumentError' do
-        expect { instance }.to raise_error(ArgumentError)
+
+    describe '#export' do
+      let(:options) { { } }
+      subject { instance.export(options) }
+      context 'when private key is given' do
+        let(:key) { private_key }
+        it 'exports the public key' do
+          expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
+          expect(subject.keys).to eq(%i[kty crv x kid])
+          expect(subject[:x].size).to eq(43)
+          expect(subject[:kid].size).to eq(43)
+        end
+      end
+      context 'when private key is asked for' do
+        let(:key) { private_key }
+        let(:options) { { include_private: true } }
+        it 'exports the private key' do
+          expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
+          expect(subject.keys).to eq(%i[kty crv x kid d])
+          expect(subject[:x].size).to eq(43)
+          expect(subject[:d].size).to eq(43)
+          expect(subject[:kid].size).to eq(43)
+        end
       end
     end
   end
-
-  describe '#private?' do
-    subject { instance.private? }
-    context 'when private key is given' do
-      let(:key) { private_key }
-      it { is_expected.to eq(true) }
-    end
-    context 'when public key is given' do
-      let(:key) { public_key }
-      it { is_expected.to eq(false) }
-    end
-  end
-
-  describe '#export' do
-    subject { instance.export }
-    context 'when private key is given' do
-      let(:key) { private_key }
-      it 'exports the public key' do
-         expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
-         expect(subject.keys).to eq([:kty, :crv, :x, :kid])
-         expect(subject[:x].size).to eq(43)
-         expect(subject[:kid].size).to eq(43)
-      end
-    end
-  end
-end if defined?(RbNaCl)
+end

--- a/spec/jwk/okp_spec.rb
+++ b/spec/jwk/okp_spec.rb
@@ -77,8 +77,9 @@ if defined?(RbNaCl)
         let(:exported_key) { described_class.new(public_key).export }
         it 'creates a new instance of the class' do
           expect(subject.private?).to eq(false)
-          expect(subject.keypair).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
-          expect(subject.keypair.to_bytes).to eq(public_key.to_bytes)
+          expect(subject.verify_key).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
+          expect(subject.signing_key).to eq(nil)
+          expect(subject.verify_key.to_bytes).to eq(public_key.to_bytes)
           expect(subject.kid).to eq(exported_key[:kid])
         end
       end
@@ -87,8 +88,9 @@ if defined?(RbNaCl)
         let(:exported_key) { described_class.new(private_key).export(include_private: true) }
         it 'creates a new instance of the class' do
           expect(subject.private?).to eq(true)
-          expect(subject.keypair).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
-          expect(subject.keypair.to_bytes).to eq(public_key.to_bytes)
+          expect(subject.verify_key).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
+          expect(subject.signing_key).to be_a(RbNaCl::Signatures::Ed25519::SigningKey)
+          expect(subject.verify_key.to_bytes).to eq(public_key.to_bytes)
           expect(subject.kid).to eq(exported_key[:kid])
         end
       end

--- a/spec/jwk/okp_spec.rb
+++ b/spec/jwk/okp_spec.rb
@@ -1,95 +1,97 @@
 # frozen_string_literal: true
 
-describe JWT::JWK::OKP do
-  let(:private_key) { RbNaCl::Signatures::Ed25519::SigningKey.new(SecureRandom.hex) }
-  let(:public_key)  { private_key.verify_key }
-  let(:key)         { nil }
+if defined?(RbNaCl)
+  describe JWT::JWK::OKP do
+    let(:private_key) { RbNaCl::Signatures::Ed25519::SigningKey.new(SecureRandom.hex) }
+    let(:public_key)  { private_key.verify_key }
+    let(:key)         { nil }
 
-  subject(:instance) { described_class.new(key) }
+    subject(:instance) { described_class.new(key) }
 
-  describe '.new' do
-    context 'when private key is given' do
+    describe '.new' do
+      context 'when private key is given' do
+        let(:key) { private_key }
+        it { is_expected.to be_a(described_class) }
+      end
+      context 'when public key is given' do
+        let(:key) { public_key }
+        it { is_expected.to be_a(described_class) }
+      end
+      context 'when something else than a public or private key is given' do
+        let(:key) { OpenSSL::PKey::RSA.new(2048) }
+        it 'raises an ArgumentError' do
+          expect { instance }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    describe '#public_key' do
       let(:key) { private_key }
-      it { is_expected.to be_a(described_class) }
-    end
-    context 'when public key is given' do
-      let(:key) { public_key }
-      it { is_expected.to be_a(described_class) }
-    end
-    context 'when something else than a public or private key is given' do
-      let(:key) { OpenSSL::PKey::RSA.new(2048) }
-      it 'raises an ArgumentError' do
-        expect { instance }.to raise_error(ArgumentError)
-      end
-    end
-  end
-
-  describe '#public_key' do
-    let(:key) { private_key }
-    subject { instance.public_key }
-    it 'is the verify key' do
-      expect(subject).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
-    end
-  end
-
-  describe '#private?' do
-    subject { instance.private? }
-    context 'when private key is given' do
-      let(:key) { private_key }
-      it { is_expected.to eq(true) }
-    end
-    context 'when public key is given' do
-      let(:key) { public_key }
-      it { is_expected.to eq(false) }
-    end
-  end
-
-  describe '#export' do
-    let(:options) { { } }
-    subject { instance.export(options) }
-    context 'when private key is given' do
-      let(:key) { private_key }
-      it 'exports the public key' do
-        expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
-        expect(subject.keys).to eq(%i[kty crv x kid])
-        expect(subject[:x].size).to eq(43)
-        expect(subject[:kid].size).to eq(43)
-      end
-    end
-    context 'when private key is asked for' do
-      let(:key) { private_key }
-      let(:options) { { include_private: true } }
-      it 'exports the private key' do
-        expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
-        expect(subject.keys).to eq(%i[kty crv x kid d])
-        expect(subject[:x].size).to eq(43)
-        expect(subject[:d].size).to eq(43)
-        expect(subject[:kid].size).to eq(43)
-      end
-    end
-  end
-
-  describe '.import' do
-    subject { described_class.import(exported_key) }
-    
-    context 'when exported public key is given' do
-      let(:exported_key) { described_class.new(public_key).export }
-      it 'creates a new instance of the class' do
-        expect(subject.private?).to eq(false)
-        expect(subject.keypair).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
-        expect(subject.keypair.to_bytes).to eq(public_key.to_bytes)
-        expect(subject.kid).to eq(exported_key[:kid])
+      subject { instance.public_key }
+      it 'is the verify key' do
+        expect(subject).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
       end
     end
 
-    context 'when exported private key is given' do
-      let(:exported_key) { described_class.new(private_key).export(include_private: true) }
-      it 'creates a new instance of the class' do
-        expect(subject.private?).to eq(true)
-        expect(subject.keypair).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
-        expect(subject.keypair.to_bytes).to eq(public_key.to_bytes)
-        expect(subject.kid).to eq(exported_key[:kid])
+    describe '#private?' do
+      subject { instance.private? }
+      context 'when private key is given' do
+        let(:key) { private_key }
+        it { is_expected.to eq(true) }
+      end
+      context 'when public key is given' do
+        let(:key) { public_key }
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#export' do
+      let(:options) { { } }
+      subject { instance.export(options) }
+      context 'when private key is given' do
+        let(:key) { private_key }
+        it 'exports the public key' do
+          expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
+          expect(subject.keys).to eq(%i[kty crv x kid])
+          expect(subject[:x].size).to eq(43)
+          expect(subject[:kid].size).to eq(43)
+        end
+      end
+      context 'when private key is asked for' do
+        let(:key) { private_key }
+        let(:options) { { include_private: true } }
+        it 'exports the private key' do
+          expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
+          expect(subject.keys).to eq(%i[kty crv x kid d])
+          expect(subject[:x].size).to eq(43)
+          expect(subject[:d].size).to eq(43)
+          expect(subject[:kid].size).to eq(43)
+        end
+      end
+    end
+
+    describe '.import' do
+      subject { described_class.import(exported_key) }
+
+      context 'when exported public key is given' do
+        let(:exported_key) { described_class.new(public_key).export }
+        it 'creates a new instance of the class' do
+          expect(subject.private?).to eq(false)
+          expect(subject.keypair).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
+          expect(subject.keypair.to_bytes).to eq(public_key.to_bytes)
+          expect(subject.kid).to eq(exported_key[:kid])
+        end
+      end
+
+      context 'when exported private key is given' do
+        let(:exported_key) { described_class.new(private_key).export(include_private: true) }
+        it 'creates a new instance of the class' do
+          expect(subject.private?).to eq(true)
+          expect(subject.keypair).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
+          expect(subject.keypair.to_bytes).to eq(public_key.to_bytes)
+          expect(subject.kid).to eq(exported_key[:kid])
+        end
       end
     end
   end
-end if defined?(RbNaCl)
+end

--- a/spec/jwk/okp_spec.rb
+++ b/spec/jwk/okp_spec.rb
@@ -1,76 +1,95 @@
 # frozen_string_literal: true
 
-require_relative '../spec_helper'
-require 'jwt'
+describe JWT::JWK::OKP do
+  let(:private_key) { RbNaCl::Signatures::Ed25519::SigningKey.new(SecureRandom.hex) }
+  let(:public_key)  { private_key.verify_key }
+  let(:key)         { nil }
 
-if defined?(RbNaCl)
-  describe JWT::JWK::OKP do
-    let(:private_key) { RbNaCl::Signatures::Ed25519::SigningKey.new(SecureRandom.hex) }
-    let(:public_key)  { private_key.verify_key }
-    let(:key) { nil }
+  subject(:instance) { described_class.new(key) }
 
-    subject(:instance) { described_class.new(key) }
-
-    describe '.new' do
-      context 'when private key is given' do
-        let(:key) { private_key }
-        it { is_expected.to be_a(described_class) }
-      end
-      context 'when public key is given' do
-        let(:key) { public_key }
-        it { is_expected.to be_a(described_class) }
-      end
-      context 'when something else than a public or private key is given' do
-        let(:key) { OpenSSL::PKey::RSA.new(2048) }
-        it 'raises an ArgumentError' do
-          expect { instance }.to raise_error(ArgumentError)
-        end
-      end
-    end
-
-    describe '#public_key' do
+  describe '.new' do
+    context 'when private key is given' do
       let(:key) { private_key }
-      subject { instance.public_key }
-      it 'is the verify key' do
-        expect(subject).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
-      end
+      it { is_expected.to be_a(described_class) }
     end
-
-    describe '#private?' do
-      subject { instance.private? }
-      context 'when private key is given' do
-        let(:key) { private_key }
-        it { is_expected.to eq(true) }
-      end
-      context 'when public key is given' do
-        let(:key) { public_key }
-        it { is_expected.to eq(false) }
-      end
+    context 'when public key is given' do
+      let(:key) { public_key }
+      it { is_expected.to be_a(described_class) }
     end
-
-    describe '#export' do
-      let(:options) { { } }
-      subject { instance.export(options) }
-      context 'when private key is given' do
-        let(:key) { private_key }
-        it 'exports the public key' do
-          expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
-          expect(subject.keys).to eq(%i[kty crv x kid])
-          expect(subject[:x].size).to eq(43)
-          expect(subject[:kid].size).to eq(43)
-        end
-      end
-      context 'when private key is asked for' do
-        let(:key) { private_key }
-        let(:options) { { include_private: true } }
-        it 'exports the private key' do
-          expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
-          expect(subject.keys).to eq(%i[kty crv x kid d])
-          expect(subject[:x].size).to eq(43)
-          expect(subject[:d].size).to eq(43)
-          expect(subject[:kid].size).to eq(43)
-        end
+    context 'when something else than a public or private key is given' do
+      let(:key) { OpenSSL::PKey::RSA.new(2048) }
+      it 'raises an ArgumentError' do
+        expect { instance }.to raise_error(ArgumentError)
       end
     end
   end
-end
+
+  describe '#public_key' do
+    let(:key) { private_key }
+    subject { instance.public_key }
+    it 'is the verify key' do
+      expect(subject).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
+    end
+  end
+
+  describe '#private?' do
+    subject { instance.private? }
+    context 'when private key is given' do
+      let(:key) { private_key }
+      it { is_expected.to eq(true) }
+    end
+    context 'when public key is given' do
+      let(:key) { public_key }
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe '#export' do
+    let(:options) { { } }
+    subject { instance.export(options) }
+    context 'when private key is given' do
+      let(:key) { private_key }
+      it 'exports the public key' do
+        expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
+        expect(subject.keys).to eq(%i[kty crv x kid])
+        expect(subject[:x].size).to eq(43)
+        expect(subject[:kid].size).to eq(43)
+      end
+    end
+    context 'when private key is asked for' do
+      let(:key) { private_key }
+      let(:options) { { include_private: true } }
+      it 'exports the private key' do
+        expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
+        expect(subject.keys).to eq(%i[kty crv x kid d])
+        expect(subject[:x].size).to eq(43)
+        expect(subject[:d].size).to eq(43)
+        expect(subject[:kid].size).to eq(43)
+      end
+    end
+  end
+
+  describe '.import' do
+    subject { described_class.import(exported_key) }
+    
+    context 'when exported public key is given' do
+      let(:exported_key) { described_class.new(public_key).export }
+      it 'creates a new instance of the class' do
+        expect(subject.private?).to eq(false)
+        expect(subject.keypair).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
+        expect(subject.keypair.to_bytes).to eq(public_key.to_bytes)
+        expect(subject.kid).to eq(exported_key[:kid])
+      end
+    end
+
+    context 'when exported private key is given' do
+      let(:exported_key) { described_class.new(private_key).export(include_private: true) }
+      it 'creates a new instance of the class' do
+        expect(subject.private?).to eq(true)
+        expect(subject.keypair).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
+        expect(subject.keypair.to_bytes).to eq(public_key.to_bytes)
+        expect(subject.kid).to eq(exported_key[:kid])
+      end
+    end
+  end
+end if defined?(RbNaCl)

--- a/spec/jwk/okp_spec.rb
+++ b/spec/jwk/okp_spec.rb
@@ -38,4 +38,17 @@ describe JWT::JWK::OKP do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe '#export' do
+    subject { instance.export }
+    context 'when private key is given' do
+      let(:key) { private_key }
+      it 'exports the public key' do
+         expect(subject).to include(crv: 'Ed25519', kty: 'OKP')
+         expect(subject.keys).to eq([:kty, :crv, :x, :kid])
+         expect(subject[:x].size).to eq(43)
+         expect(subject[:kid].size).to eq(43)
+      end
+    end
+  end
 end if defined?(RbNaCl)

--- a/spec/jwk/okp_spec.rb
+++ b/spec/jwk/okp_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'jwt'
+
+describe JWT::JWK::OKP do
+  let(:private_key) { RbNaCl::Signatures::Ed25519::SigningKey.new(SecureRandom.hex) }
+  let(:public_key)  { private_key.verify_key }
+
+  describe '.new' do
+    context 'when private key is given' do
+      it 'creates a new instance' do
+        expect(described_class.new(private_key)).to be_a(described_class)
+      end
+    end
+    context 'when public key is given' do
+      it 'creates a new instance' do
+        expect(described_class.new(public_key)).to be_a(described_class)
+      end
+    end
+    context 'when something else than a public or private key is given' do
+      it 'raises an ArgumentError' do
+        expect { described_class.new(OpenSSL::PKey::RSA.new(2048)) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end if defined?(RbNaCl)

--- a/spec/jwk/okp_spec.rb
+++ b/spec/jwk/okp_spec.rb
@@ -28,6 +28,14 @@ if defined?(RbNaCl)
       end
     end
 
+    describe '#public_key' do
+      let(:key) { private_key }
+      subject { instance.public_key }
+      it 'is the verify key' do
+        expect(subject).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
+      end
+    end
+
     describe '#private?' do
       subject { instance.private? }
       context 'when private key is given' do

--- a/spec/jwk/okp_spec.rb
+++ b/spec/jwk/okp_spec.rb
@@ -25,9 +25,9 @@ if defined?(RbNaCl)
       end
     end
 
-    describe '#public_key' do
+    describe '#verify_key' do
       let(:key) { private_key }
-      subject { instance.public_key }
+      subject { instance.verify_key }
       it 'is the verify key' do
         expect(subject).to be_a(RbNaCl::Signatures::Ed25519::VerifyKey)
       end

--- a/spec/jwk/rsa_spec.rb
+++ b/spec/jwk/rsa_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../spec_helper'
-require 'jwt'
-
 describe JWT::JWK::RSA do
   let(:rsa_key) { OpenSSL::PKey::RSA.new(2048) }
 

--- a/spec/jwk/rsa_spec.rb
+++ b/spec/jwk/rsa_spec.rb
@@ -96,9 +96,9 @@ describe JWT::JWK::RSA do
     end
 
     context 'when jwk_data is given without e and/or n' do
-      let(:params) { { kty: "RSA" } }
+      let(:params) { { kty: 'RSA' } }
       it 'raises an error' do
-        expect { subject }.to raise_error(JWT::JWKError, "Key format is invalid for RSA")
+        expect { subject }.to raise_error(JWT::JWKError, 'Key format is invalid for RSA')
       end
     end
   end

--- a/spec/jwk/thumbprint_spec.rb
+++ b/spec/jwk/thumbprint_spec.rb
@@ -22,5 +22,23 @@ describe JWT::JWK::Thumbprint do
         expect(described_class.new(jwk).to_s).to eq('NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs')
       end
     end
+    context 'when HMAC key is given' do
+      let(:hmac_key) {
+        '
+        {
+          "kty":"oct",
+          "kid":"wPf4ZF5qlzoFxsGkft4eu1iWcehgAcahZL4XPV4dT-s",
+          "alg":"HS512",
+          "k":"B4uZ7IbZTnjdCQjUBXTpzMUznCYj3wdYDZcceeU0mLg"
+        }
+        '
+      }
+
+      let(:jwk) { JWT::JWK.import(JSON.parse(hmac_key)) }
+
+      it 'calculates the correct thumbprint' do
+        expect(described_class.new(jwk).to_s).to eq('wPf4ZF5qlzoFxsGkft4eu1iWcehgAcahZL4XPV4dT-s')
+      end
+    end
   end
 end

--- a/spec/jwk/thumbprint_spec.rb
+++ b/spec/jwk/thumbprint_spec.rb
@@ -6,7 +6,8 @@ require 'jwt'
 describe JWT::JWK::Thumbprint do
   describe '#to_s' do
     context 'when example from RFC is given' do
-      let(:rfc_example) { '{ "kty": "RSA",
+      let(:rfc_example) {
+        '{ "kty": "RSA",
         "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAt' \
               'VT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn6' \
               '4tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FD' \
@@ -15,9 +16,10 @@ describe JWT::JWK::Thumbprint do
               'aQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
         "e": "AQAB",
         "alg": "RS256",
-        "kid": "2011-04-29" }' }
+        "kid": "2011-04-29" }'
+      }
 
-      let(:jwk) { JWT::JWK.import(JSON.parse(rfc_example))}
+      let(:jwk) { JWT::JWK.import(JSON.parse(rfc_example)) }
 
       it 'calculates the correct thumbprint' do
         expect(described_class.new(jwk).to_s).to eq('NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs')

--- a/spec/jwk/thumbprint_spec.rb
+++ b/spec/jwk/thumbprint_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'jwt'
+
+describe JWT::JWK::Thumbprint do
+  describe '#to_s' do
+    context 'when example from RFC is given' do
+      let(:rfc_example) { '{ "kty": "RSA",
+        "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAt' \
+              'VT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn6' \
+              '4tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FD' \
+              'W2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n9' \
+              '1CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINH' \
+              'aQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+        "e": "AQAB",
+        "alg": "RS256",
+        "kid": "2011-04-29" }' }
+
+      let(:jwk) { JWT::JWK.import(JSON.parse(rfc_example))}
+
+      it 'calculates the correct thumbprint' do
+        expect(described_class.new(jwk).to_s).to eq('NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs')
+      end
+    end
+  end
+end

--- a/spec/jwk/thumbprint_spec.rb
+++ b/spec/jwk/thumbprint_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../spec_helper'
-require 'jwt'
-
 describe JWT::JWK::Thumbprint do
   describe '#to_s' do
     context 'when example from RFC is given' do

--- a/spec/jwk_spec.rb
+++ b/spec/jwk_spec.rb
@@ -2,12 +2,12 @@
 
 describe JWT::JWK do
   let(:rsa_key) { OpenSSL::PKey::RSA.new(2048) }
-  let(:ec_key) { OpenSSL::PKey::EC.new("secp384r1").generate_key }
+  let(:ec_key) { OpenSSL::PKey::EC.new('secp384r1').generate_key }
 
   describe '.import' do
     let(:keypair) { rsa_key.public_key }
     let(:exported_key) { described_class.new(keypair).export }
-    let(:params)  { exported_key }
+    let(:params) { exported_key }
 
     subject { described_class.import(params) }
 
@@ -34,7 +34,7 @@ describe JWT::JWK do
 
     context 'when keypair with defined kid is imported' do
       it 'returns the predefined kid if jwt_data contains a kid' do
-        params[:kid] = "CUSTOM_KID"
+        params[:kid] = 'CUSTOM_KID'
         expect(subject.export).to eq(params)
       end
     end

--- a/spec/jwk_spec.rb
+++ b/spec/jwk_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'jwt'
-
 describe JWT::JWK do
   let(:rsa_key) { OpenSSL::PKey::RSA.new(2048) }
   let(:ec_key) { OpenSSL::PKey::EC.new("secp384r1").generate_key }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,8 @@ end
 
 SimpleCov.start if ENV['COVERAGE']
 
+require 'jwt'
+
 CERT_PATH = File.join(File.dirname(__FILE__), 'fixtures', 'certs')
 
 RSpec.configure do |config|


### PR DESCRIPTION
Started to look into supporting the Ed25519 algorithm for the JWKs (https://tools.ietf.org/html/rfc8037)

Also while doing this I realized that not all keys come in pairs so therefore was thinking to deprecate the following methods

```
::JWT::JWK::RSA#keypair
::JWT::JWK::RSA#private_key
::JWT::JWK::RSA#public_key
```

To favor the more specific methods
```
::JWT::JWK::[RSA/EC/HMAC/OKP]#verify_key
::JWT::JWK::[RSA/EC/HMAC/OKP]#signing_key
```

This also affects the `::JWT::JWK::EC` and `::JWT::JWK::HMAC` APIs. But since these have not been in any official release we could maybe just not support the old methods.

I'll work on this whenever I have the time and energy. Comments are welcome whenever!