### PR TITLE
Don't recommend installing gem with sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you have further questions related to development or usage, join us: [ruby-jw
 
 ### Using Rubygems:
 ```bash
-sudo gem install jwt
+gem install jwt
 ```
 
 ### Using Bundler:


### PR DESCRIPTION
_Not_ installing gems using `sudo` has long been considered a best practice.

The original post that popularized this from 10 years has since gone offline, but [it's cached here](https://web.archive.org/web/20101101064608/http://all-thing.net/sudo-gem-install-considered-harmful).  But since everything old is new again, this even came up again in [this week's Ruby Weekly](https://rubyweekly.com/issues/531) just this week (linking to [this new post](https://www.moncefbelyamani.com/why-you-should-never-use-sudo-to-install-ruby-gems/)).

Here are a couple more [classics](https://thoughtbot.com/blog/psa-do-not-use-system-ruby) of the [genre](https://stackoverflow.com/questions/2119064/sudo-gem-install-or-gem-install-and-gem-locations).