### PR TITLE
Document function and add tests for verify claims method

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,12 @@ rescue JWT::ExpiredSignature
 end
 ```
 
+The Expiration Claim verification can be disabled.
+```ruby
+# Decode token without raising JWT::ExpiredSignature error
+JWT.decode token, hmac_secret, true, { verify_expiration: false, algorithm: 'HS256' }
+```
+
 **Adding Leeway**
 
 ```ruby
@@ -329,6 +335,12 @@ begin
 rescue JWT::ImmatureSignature
   # Handle invalid token, e.g. logout user or deny access
 end
+```
+
+The Not Before Claim verification can be disabled.
+```ruby
+# Decode token without raising JWT::ImmatureSignature error
+JWT.decode token, hmac_secret, true, { verify_not_before: false, algorithm: 'HS256' }
 ```
 
 **Adding Leeway**

--- a/spec/jwt/verify_spec.rb
+++ b/spec/jwt/verify_spec.rb
@@ -225,5 +225,30 @@ module JWT # rubocop:disable Metrics/ModuleLength
         Verify.verify_sub(base_payload.merge('sub' => sub), options.merge(sub: sub))
       end
     end
+
+    context '.verify_claims' do
+      let(:fail_verifications_options) { { iss: 'mismatched-issuer', aud: 'no-match', sub: 'some subject' } }
+      let(:fail_verifications_payload) { {
+        'exp' => (Time.now.to_i - 50),
+        'jti' => '   ',
+        'iss' => 'some-issuer',
+        'nbf' => (Time.now.to_i + 50),
+        'iat' => 'not a number',
+        'sub' => 'not-a-match' } }
+
+      %w[verify_aud verify_expiration verify_iat verify_iss verify_jti verify_not_before verify_sub].each do |method|
+        let(:payload) { base_payload.merge(fail_verifications_payload) }
+        it "must skip verification when #{method} option is set to false" do
+          Verify.verify_claims(payload, options.merge("#{method}" => false))
+        end
+
+        it "must raise error when #{method} option is set to true" do
+          expect do
+            Verify.verify_claims(payload, options.merge("#{method}" => true).merge(fail_verifications_options))
+          end.to raise_error
+        end
+      end
+
+    end
   end
 end

--- a/spec/jwt/verify_spec.rb
+++ b/spec/jwt/verify_spec.rb
@@ -228,27 +228,29 @@ module JWT # rubocop:disable Metrics/ModuleLength
 
     context '.verify_claims' do
       let(:fail_verifications_options) { { iss: 'mismatched-issuer', aud: 'no-match', sub: 'some subject' } }
-      let(:fail_verifications_payload) { {
-        'exp' => (Time.now.to_i - 50),
-        'jti' => '   ',
-        'iss' => 'some-issuer',
-        'nbf' => (Time.now.to_i + 50),
-        'iat' => 'not a number',
-        'sub' => 'not-a-match' } }
+      let(:fail_verifications_payload) {
+        {
+          'exp' => (Time.now.to_i - 50),
+          'jti' => '   ',
+          'iss' => 'some-issuer',
+          'nbf' => (Time.now.to_i + 50),
+          'iat' => 'not a number',
+          'sub' => 'not-a-match'
+        }
+      }
 
       %w[verify_aud verify_expiration verify_iat verify_iss verify_jti verify_not_before verify_sub].each do |method|
         let(:payload) { base_payload.merge(fail_verifications_payload) }
         it "must skip verification when #{method} option is set to false" do
-          Verify.verify_claims(payload, options.merge("#{method}" => false))
+          Verify.verify_claims(payload, options.merge(method => false))
         end
 
         it "must raise error when #{method} option is set to true" do
           expect do
-            Verify.verify_claims(payload, options.merge("#{method}" => true).merge(fail_verifications_options))
+            Verify.verify_claims(payload, options.merge(method => true).merge(fail_verifications_options))
           end.to raise_error
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
Had to dig through the code to find out how to disable verifications. Decided to add tests for the `verify_claims` method because it is the one using the options to determine which claims to verify.