### PR TITLE
Ignore casing of algorithm

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -126,11 +126,12 @@ Style/MethodCallWithoutArgsParentheses:
   Exclude:
     - 'spec/jwt_spec.rb'
 
-# Offense count: 1
+# Offense count: 2
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: module_function, extend_self
 Style/ModuleFunction:
   Exclude:
+    - 'lib/jwt/algos.rb'
     - 'lib/jwt/signature.rb'
 
 # Offense count: 1

--- a/lib/jwt/algos.rb
+++ b/lib/jwt/algos.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'jwt/algos/hmac'
+require 'jwt/algos/eddsa'
+require 'jwt/algos/ecdsa'
+require 'jwt/algos/rsa'
+require 'jwt/algos/ps'
+require 'jwt/algos/unsupported'
+
+# JWT::Signature module
+module JWT
+  # Signature logic for JWT
+  module Algos
+    extend self
+    ALGOS = [
+      Algos::Hmac,
+      Algos::Ecdsa,
+      Algos::Rsa,
+      Algos::Eddsa,
+      Algos::Ps,
+      Algos::Unsupported
+    ].freeze
+
+    def find(algorithm)
+      ALGOS.each do |alg|
+        code = alg.const_get(:SUPPORTED).find {|a| a.upcase == algorithm.upcase }
+        return [alg, code] if code
+      end
+      nil
+    end
+  end
+end

--- a/lib/jwt/algos.rb
+++ b/lib/jwt/algos.rb
@@ -13,6 +13,7 @@ module JWT
   # Signature logic for JWT
   module Algos
     extend self
+
     ALGOS = [
       Algos::Hmac,
       Algos::Ecdsa,

--- a/lib/jwt/algos.rb
+++ b/lib/jwt/algos.rb
@@ -32,9 +32,8 @@ module JWT
 
     def indexed
       @indexed ||= begin
-        algos = ALGOS.dup
-        fallback = [algos.pop, nil]
-        algos.each_with_object(Hash.new(fallback)) do |alg, hash|
+        fallback = [Algos::Unsupported, nil]
+        ALGOS.each_with_object(Hash.new(fallback)) do |alg, hash|
           alg.const_get(:SUPPORTED).each do |code|
             hash[code.downcase] = [alg, code]
           end

--- a/lib/jwt/algos/eddsa.rb
+++ b/lib/jwt/algos/eddsa.rb
@@ -3,7 +3,7 @@ module JWT
     module Eddsa
       module_function
 
-      SUPPORTED = %w[ED25519].freeze
+      SUPPORTED = %w[Ed25519].freeze
 
       def sign(to_sign)
         algorithm, msg, key = to_sign.values

--- a/lib/jwt/algos/eddsa.rb
+++ b/lib/jwt/algos/eddsa.rb
@@ -3,7 +3,7 @@ module JWT
     module Eddsa
       module_function
 
-      SUPPORTED = %w[Ed25519].freeze
+      SUPPORTED = %w[ED25519].freeze
 
       def sign(to_sign)
         algorithm, msg, key = to_sign.values

--- a/lib/jwt/algos/none.rb
+++ b/lib/jwt/algos/none.rb
@@ -5,9 +5,11 @@ module JWT
 
       SUPPORTED = %w[none].freeze
 
-      def verify(*); end
-
       def sign(*); end
+
+      def verify(*)
+        true
+      end
     end
   end
 end

--- a/lib/jwt/algos/none.rb
+++ b/lib/jwt/algos/none.rb
@@ -4,11 +4,10 @@ module JWT
       module_function
 
       SUPPORTED = %w[none].freeze
-      def verify(*)
-      end
 
-      def sign(*)
-      end
+      def verify(*); end
+
+      def sign(*); end
     end
   end
 end

--- a/lib/jwt/algos/none.rb
+++ b/lib/jwt/algos/none.rb
@@ -1,0 +1,14 @@
+module JWT
+  module Algos
+    module None
+      module_function
+
+      SUPPORTED = ['none']
+      def verify(*)
+      end
+
+      def sign(*)
+      end
+    end
+  end
+end

--- a/lib/jwt/algos/none.rb
+++ b/lib/jwt/algos/none.rb
@@ -3,7 +3,7 @@ module JWT
     module None
       module_function
 
-      SUPPORTED = ['none']
+      SUPPORTED = %w[none].freeze
       def verify(*)
       end
 

--- a/lib/jwt/algos/unsupported.rb
+++ b/lib/jwt/algos/unsupported.rb
@@ -4,6 +4,7 @@ module JWT
       module_function
 
       SUPPORTED = [].freeze
+
       def verify(*)
         raise JWT::VerificationError, 'Algorithm not supported'
       end

--- a/lib/jwt/algos/unsupported.rb
+++ b/lib/jwt/algos/unsupported.rb
@@ -5,12 +5,12 @@ module JWT
 
       SUPPORTED = [].freeze
 
-      def verify(*)
-        raise JWT::VerificationError, 'Algorithm not supported'
-      end
-
       def sign(*)
         raise NotImplementedError, 'Unsupported signing method'
+      end
+
+      def verify(*)
+        raise JWT::VerificationError, 'Algorithm not supported'
       end
     end
   end

--- a/lib/jwt/algos/unsupported.rb
+++ b/lib/jwt/algos/unsupported.rb
@@ -3,7 +3,7 @@ module JWT
     module Unsupported
       module_function
 
-      SUPPORTED = Object.new.tap { |object| object.define_singleton_method(:find) { |*| true } }
+      SUPPORTED = []
       def verify(*)
         raise JWT::VerificationError, 'Algorithm not supported'
       end

--- a/lib/jwt/algos/unsupported.rb
+++ b/lib/jwt/algos/unsupported.rb
@@ -3,7 +3,7 @@ module JWT
     module Unsupported
       module_function
 
-      SUPPORTED = []
+      SUPPORTED = [].freeze
       def verify(*)
         raise JWT::VerificationError, 'Algorithm not supported'
       end

--- a/lib/jwt/algos/unsupported.rb
+++ b/lib/jwt/algos/unsupported.rb
@@ -3,7 +3,7 @@ module JWT
     module Unsupported
       module_function
 
-      SUPPORTED = Object.new.tap { |object| object.define_singleton_method(:include?) { |*| true } }
+      SUPPORTED = Object.new.tap { |object| object.define_singleton_method(:find) { |*| true } }
       def verify(*)
         raise JWT::VerificationError, 'Algorithm not supported'
       end

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -43,7 +43,7 @@ module JWT
     end
 
     def options_includes_algo_in_header?
-      allowed_algorithms.any? { |alg| alg.casecmp?(header['alg']) }
+      allowed_algorithms.any? { |alg| alg.casecmp(header['alg']) == 0 }
     end
 
     def allowed_algorithms

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -43,22 +43,23 @@ module JWT
     end
 
     def options_includes_algo_in_header?
-      allowed_algorithms.include? header['alg']
+      allowed_algorithms.include? header['alg'].upcase
     end
 
     def allowed_algorithms
       # Order is very important - first check for string keys, next for symbols
-      if @options.key?('algorithm')
-        [@options['algorithm']]
-      elsif @options.key?(:algorithm)
-        [@options[:algorithm]]
-      elsif @options.key?('algorithms')
-        @options['algorithms'] || []
-      elsif @options.key?(:algorithms)
-        @options[:algorithms] || []
-      else
-        []
-      end
+      algos = if @options.key?('algorithm')
+                @options['algorithm']
+              elsif @options.key?(:algorithm)
+                @options[:algorithm]
+              elsif @options.key?('algorithms')
+                @options['algorithms']
+              elsif @options.key?(:algorithms)
+                @options[:algorithms]
+              else
+                []
+              end
+      Array(algos).map(&:upcase)
     end
 
     def find_key(&keyfinder)

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -43,7 +43,7 @@ module JWT
     end
 
     def options_includes_algo_in_header?
-      allowed_algorithms.any? { |alg| alg.casecmp(header['alg']) == 0 }
+      allowed_algorithms.any? { |alg| alg.casecmp(header['alg']).zero? }
     end
 
     def allowed_algorithms

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -43,7 +43,7 @@ module JWT
     end
 
     def options_includes_algo_in_header?
-      allowed_algorithms.include? header['alg'].upcase
+      allowed_algorithms.any? { |alg| alg.casecmp?(header['alg']) }
     end
 
     def allowed_algorithms
@@ -59,7 +59,7 @@ module JWT
       else
         []
       end
-      Array(algos).map(&:upcase)
+      Array(algos)
     end
 
     def find_key(&keyfinder)

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -49,16 +49,16 @@ module JWT
     def allowed_algorithms
       # Order is very important - first check for string keys, next for symbols
       algos = if @options.key?('algorithm')
-                @options['algorithm']
-              elsif @options.key?(:algorithm)
-                @options[:algorithm]
-              elsif @options.key?('algorithms')
-                @options['algorithms']
-              elsif @options.key?(:algorithms)
-                @options[:algorithms]
-              else
-                []
-              end
+        @options['algorithm']
+      elsif @options.key?(:algorithm)
+        @options[:algorithm]
+      elsif @options.key?('algorithms')
+        @options['algorithms']
+      elsif @options.key?(:algorithms)
+        @options[:algorithms]
+      else
+        []
+      end
       Array(algos).map(&:upcase)
     end
 

--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -11,10 +11,10 @@ module JWT
     ALG_KEY  = 'alg'.freeze
 
     def initialize(options)
-      @payload   = options[:payload]
-      @key       = options[:key]
+      @payload = options[:payload]
+      @key = options[:key]
       _, @algorithm = Algos.find(options[:algorithm])
-      @headers   = options[:headers].each_with_object({}) { |(key, value), headers| headers[key.to_s] = value }
+      @headers = options[:headers].each_with_object({}) { |(key, value), headers| headers[key.to_s] = value }
     end
 
     def segments

--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative './algos'
 require_relative './claims_validator'
 
 # JWT::Encode module
@@ -12,7 +13,7 @@ module JWT
     def initialize(options)
       @payload   = options[:payload]
       @key       = options[:key]
-      @algorithm = options[:algorithm]
+      _, @algorithm = Algos.find(options[:algorithm])
       @headers   = options[:headers].each_with_object({}) { |(key, value), headers| headers[key.to_s] = value }
     end
 

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -23,7 +23,7 @@ module JWT
     end
 
     def verify(algorithm, key, signing_input, signature)
-      return true if algorithm.upcase == 'NONE'
+      return true if algorithm.casecmp?('none')
 
       raise JWT::DecodeError, 'No verification key available' unless key
 

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -31,6 +31,7 @@ module JWT
     ToVerify = Struct.new(:algorithm, :public_key, :signing_input, :signature)
 
     def sign(algorithm, msg, key)
+      algorithm = algorithm.upcase
       algo = ALGOS.find do |alg|
         alg.const_get(:SUPPORTED).include? algorithm
       end
@@ -38,7 +39,8 @@ module JWT
     end
 
     def verify(algorithm, key, signing_input, signature)
-      return true if algorithm == 'none'
+      algorithm = algorithm.upcase
+      return true if algorithm == 'NONE'
 
       raise JWT::DecodeError, 'No verification key available' unless key
 

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -23,7 +23,7 @@ module JWT
     end
 
     def verify(algorithm, key, signing_input, signature)
-      return true if algorithm.casecmp('none') == 0
+      return true if algorithm.casecmp('none').zero?
 
       raise JWT::DecodeError, 'No verification key available' unless key
 

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -23,7 +23,7 @@ module JWT
     end
 
     def verify(algorithm, key, signing_input, signature)
-      return true if algorithm.casecmp?('none')
+      return true if algorithm.casecmp('none') == 0
 
       raise JWT::DecodeError, 'No verification key available' unless key
 

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -37,8 +37,8 @@ describe JWT do
 
     if defined?(RbNaCl)
       data.merge!(
-        'Ed25519_private' =>  RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF'),
-        'Ed25519_public' => RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF').verify_key,
+        'ED25519_private' =>  RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF'),
+        'ED25519_public' => RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF').verify_key,
       )
     end
     data
@@ -190,7 +190,7 @@ describe JWT do
   end
 
   if defined?(RbNaCl)
-    %w[Ed25519].each do |alg|
+    %w[ED25519].each do |alg|
       context "alg: #{alg}" do
         before(:each) do
           data[alg] = JWT.encode payload, data["#{alg}_private"], alg

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -518,8 +518,8 @@ describe JWT do
       enc = JWT.encode(payload, '', 'hs256')
       expect(JWT.decode(enc, '')).to eq([payload, { 'alg' => 'HS256'}])
 
-      enc = JWT.encode(payload, data[:rsa_private], 'ps384')
-      expect(JWT.decode(enc, data[:rsa_public], true, algorithm: 'PS384')).to eq([payload, { 'alg' => 'PS384'}])
+      enc = JWT.encode(payload, data[:rsa_private], 'rs512')
+      expect(JWT.decode(enc, data[:rsa_public], true, algorithm: 'RS512')).to eq([payload, { 'alg' => 'RS512'}])
 
       enc = JWT.encode(payload, data[:rsa_private], 'RS512')
       expect(JWT.decode(enc, data[:rsa_public], true, algorithm: 'rs512')).to eq([payload, { 'alg' => 'RS512'}])

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -37,8 +37,8 @@ describe JWT do
 
     if defined?(RbNaCl)
       data.merge!(
-        'ED25519_private' =>  RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF'),
-        'ED25519_public' => RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF').verify_key,
+        'Ed25519_private' =>  RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF'),
+        'Ed25519_public' => RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF').verify_key,
       )
     end
     data
@@ -190,7 +190,7 @@ describe JWT do
   end
 
   if defined?(RbNaCl)
-    %w[ED25519].each do |alg|
+    %w[Ed25519].each do |alg|
       context "alg: #{alg}" do
         before(:each) do
           data[alg] = JWT.encode payload, data["#{alg}_private"], alg
@@ -516,11 +516,10 @@ describe JWT do
 
     it 'ignores algorithm casing during encode/decode' do
       enc = JWT.encode(payload, '', 'hs256')
-      expect(JWT.decode(enc, '')).to eq([payload, { 'alg' => 'hs256'}])
+      expect(JWT.decode(enc, '')).to eq([payload, { 'alg' => 'HS256'}])
 
       enc = JWT.encode(payload, data[:rsa_private], 'ps384')
-      puts JWT.decode(enc, nil, false, algorithm: 'ps384').inspect
-      expect(JWT.decode(enc, data[:rsa_public], true, algorithm: 'PS384')).to eq([payload, { 'alg' => 'ps384'}])
+      expect(JWT.decode(enc, data[:rsa_public], true, algorithm: 'PS384')).to eq([payload, { 'alg' => 'PS384'}])
 
       enc = JWT.encode(payload, data[:rsa_private], 'RS512')
       expect(JWT.decode(enc, data[:rsa_public], true, algorithm: 'rs512')).to eq([payload, { 'alg' => 'RS512'}])

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -510,4 +510,26 @@ describe JWT do
       end.not_to raise_error
     end
   end
+
+  context 'algorithm case insensitivity' do
+    let(:payload) { { 'a' => 1, 'b' => 'b' } }
+
+    it 'ignores algorithm casing during encode/decode' do
+      enc = JWT.encode(payload, '', 'hs256')
+      expect(JWT.decode(enc, '')).to eq([payload, { 'alg' => 'hs256'}])
+
+      enc = JWT.encode(payload, data[:rsa_private], 'ps384')
+      puts JWT.decode(enc, nil, false, algorithm: 'ps384').inspect
+      expect(JWT.decode(enc, data[:rsa_public], true, algorithm: 'PS384')).to eq([payload, { 'alg' => 'ps384'}])
+
+      enc = JWT.encode(payload, data[:rsa_private], 'RS512')
+      expect(JWT.decode(enc, data[:rsa_public], true, algorithm: 'rs512')).to eq([payload, { 'alg' => 'RS512'}])
+    end
+
+    it 'raises error for invalid algorithm' do
+      expect do
+        JWT.encode(payload, '', 'xyz')
+      end.to raise_error(NotImplementedError)
+    end
+  end
 end


### PR DESCRIPTION
(Updated 2/6/2021)

I am have to connect to a third party source for JWTs which transmits the algorithm as "Ed25519". This does not match the expected value in Ruby "ED25519". To remedy this:

- Ignore casing of algorithm on input
- Output correct casing of algorithm when encoding
- Consider "Ed25519" as the correct casing, as per [RFC#8037](https://tools.ietf.org/html/rfc8037) as well as the [Go](https://github.com/gbrlsnchs/jwt/blob/f423236368671cbb9216d3893ff14094d29407c6/verify_test.go#L55), [Erlang](https://github.com/potatosalad/erlang-jose/blob/c7aad59f78e16659ea9aaa8953303275c4949eef/src/jwk/jose_jwk_kty_okp_ed25519.erl#L49), [Haskell](https://github.com/tekul/jose-jwt/blob/718fe38326a59e7310a49f166a8ad36f3377727d/tests/jwks.json#L11), etc. JWT implementations.

In order to achieve this in a clean manner, I've extracted out a `JWT::Algos` module which uses a more efficient lookup (pre-indexed) to find the algo. I've also introduced `JWT::Algos::None` which is distinct from `JWT::Algos::Unsupported`