### PR TITLE
Support alternate casing "Ed25519" (lowercase "d")

### DIFF
--- a/lib/jwt/algos/eddsa.rb
+++ b/lib/jwt/algos/eddsa.rb
@@ -3,7 +3,7 @@ module JWT
     module Eddsa
       module_function
 
-      SUPPORTED = %w[ED25519].freeze
+      SUPPORTED = %w[Ed25519 ED25519].freeze
 
       def sign(to_sign)
         algorithm, msg, key = to_sign.values

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -37,6 +37,8 @@ describe JWT do
 
     if defined?(RbNaCl)
       data.merge!(
+        'Ed25519_private' =>  RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF'),
+        'Ed25519_public' => RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF').verify_key,
         'ED25519_private' =>  RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF'),
         'ED25519_public' => RbNaCl::Signatures::Ed25519::SigningKey.new('abcdefghijklmnopqrstuvwxyzABCDEF').verify_key,
       )

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -190,7 +190,7 @@ describe JWT do
   end
 
   if defined?(RbNaCl)
-    %w[ED25519].each do |alg|
+    %w[Ed25519 ED25519].each do |alg|
       context "alg: #{alg}" do
         before(:each) do
           data[alg] = JWT.encode payload, data["#{alg}_private"], alg


### PR DESCRIPTION
Currently the system requires "ED25519". However, [RFC#8037](https://tools.ietf.org/html/rfc8037) refers to it clearly as "Ed25519" (lowercase "d"), and this casing is used in various other JWT libs such as [Go](https://github.com/gbrlsnchs/jwt/blob/f423236368671cbb9216d3893ff14094d29407c6/verify_test.go#L55), [Erlang](https://github.com/potatosalad/erlang-jose/blob/c7aad59f78e16659ea9aaa8953303275c4949eef/src/jwk/jose_jwk_kty_okp_ed25519.erl#L49), and [Haskell](https://github.com/tekul/jose-jwt/blob/718fe38326a59e7310a49f166a8ad36f3377727d/tests/jwks.json#L11).