### PR TITLE
Fix references for v2.2.3 on CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [2.2.3](https://github.com/jwt/ruby-jwt/tree/2.2.3) (2021-04-19)
+## [v2.2.3](https://github.com/jwt/ruby-jwt/tree/v2.2.3) (2021-04-19)
 
-[Full Changelog](https://github.com/jwt/ruby-jwt/compare/v2.2.2...2.2.3)
+[Full Changelog](https://github.com/jwt/ruby-jwt/compare/v2.2.2...v2.2.3)
 
 **Implemented enhancements:**
 


### PR DESCRIPTION
Some references were pointing to 2.2.3 instead of v2.2.3.