### PR TITLE
Give ruby 3.0 as a string to avoid number formatting issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - "3.0"
         gemfile:
           - gemfiles/standalone.gemfile
           - gemfiles/openssl.gemfile


### PR DESCRIPTION
A trick I learned from @olleolleolle to avoid dropping the .0 from the 3.0 build