### PR TITLE
Add Support to be able to verify from multiple keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ coverage/
 .vscode/
 .bundle
 *gemfile.lock
+.byebug_history
+*.gem

--- a/lib/jwt/signature.rb
+++ b/lib/jwt/signature.rb
@@ -23,13 +23,8 @@ module JWT
     end
 
     def verify(algorithm, key, signing_input, signature)
-      return true if algorithm.casecmp('none').zero?
-
-      raise JWT::DecodeError, 'No verification key available' unless key
-
       algo, code = Algos.find(algorithm)
-      verified = algo.verify(ToVerify.new(code, key, signing_input, signature))
-      raise(JWT::VerificationError, 'Signature verification raised') unless verified
+      algo.verify(ToVerify.new(code, key, signing_input, signature))
     rescue OpenSSL::PKey::PKeyError
       raise JWT::VerificationError, 'Signature verification raised'
     ensure

--- a/spec/integration/readme_examples_spec.rb
+++ b/spec/integration/readme_examples_spec.rb
@@ -269,7 +269,6 @@ RSpec.describe 'README.md code test' do
         @cached_keys = nil if options[:invalidate] # need to reload the keys
         @cached_keys ||= { keys: [jwk.export] }
       end
-
       expect do
         JWT.decode(token, nil, true, { algorithms: ['RS512'], jwks: jwk_loader})
       end.not_to raise_error


### PR DESCRIPTION
**Problem -** 

During a security incident, if one has to rotate secrets shared with 3rd party apps, one has to ensure backward compatibility where both the old and new secrets continue to work.

**Solution -** 
Have made changes to iterate over an array of keys while verifying signature. This can be used by returning an array of keys from the `find_key` block.

PS: Will add specs if changes are ok.