### PR TITLE
Fix OpenSSL::PKey::EC public_key handing in tests

### DIFF
--- a/spec/jwk/ec_spec.rb
+++ b/spec/jwk/ec_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe JWT::JWK::EC do
     end
 
     context 'when a keypair with only public key is given' do
-      let(:keypair) { ec_key.tap { |x| x.private_key = nil } }
+      let(:keypair) { OpenSSL::PKey::EC.new(ec_key.public_key.group).tap { |ec| ec.public_key = ec_key.public_key } }
       it 'creates an instance of the class' do
         expect(subject).to be_a described_class
         expect(subject.private?).to eq false


### PR DESCRIPTION
This fixes the a EC test to be compatible when executed on recent MacOSes. Did not go deep into why it fails, but somehow setting the `private_key` to nil is not removing it from the object.