### PR TITLE
First idea of a extendable JWT decoder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,7 +50,7 @@ Style/SignalException:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 20
+  Max: 21
 
 Metrics/ClassLength:
   Max: 101

--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'jwt/base64'
+require 'jwt/extension'
 require 'jwt/json'
 require 'jwt/decode'
 require 'jwt/default_options'
@@ -14,6 +15,10 @@ require 'jwt/jwk'
 # https://tools.ietf.org/html/rfc7519
 module JWT
   include JWT::DefaultOptions
+
+  def self.included(cls)
+    cls.extend(JWT::Extension::ClassMethods)
+  end
 
   module_function
 

--- a/lib/jwt/extension.rb
+++ b/lib/jwt/extension.rb
@@ -1,0 +1,26 @@
+module JWT
+  module Extension
+    module ClassMethods
+      def decode_payload(&block)
+        @decode_payload_block = block
+      end
+
+      def decode(payload, options = {})
+        segments = ::JWT::Decode.new(payload,
+          options.delete(:key),
+          true,
+          create_decode_options(options)).decode_segments
+        {
+          header: segments.last,
+          payload: segments.first
+        }
+      end
+
+      private
+
+      def create_decode_options(given_options)
+        ::JWT::DefaultOptions::DEFAULT_OPTIONS.merge(decode_payload_proc: @decode_payload_block).merge(given_options)
+      end
+    end
+  end
+end

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+RSpec.describe JWT::Extension do
+  subject(:extension) do
+    Class.new do
+      include JWT
+    end
+  end
+
+  let(:secret) { SecureRandom.hex }
+  let(:payload) { { 'pay' => 'load'} }
+  let(:encoded_payload) { ::JWT.encode(payload, secret, 'HS256') }
+
+  describe '.decode' do
+    it { is_expected.to respond_to(:decode) }
+
+    context 'when nothing special is defined' do
+      it 'verifies a token and returns the data' do
+        expect(extension.decode(encoded_payload, key: secret)).to eq(header: { 'alg' => 'HS256' }, payload: payload)
+      end
+    end
+
+    context 'when a decode_payload block is given' do
+      before do
+        extension.decode_payload do |_header, raw_payload, _signature|
+          payload_content = JWT::JSON.parse(JWT::Base64.url_decode(raw_payload))
+          payload_content['pay'].reverse!
+          JWT::Base64.url_encode(JWT::JSON.generate(payload_content))
+        end
+      end
+
+      it 'lets before decode process the raw payload before verifying' do
+        expect(extension.decode(encoded_payload, key: secret)).to eq(header: { 'alg' => 'HS256' }, payload: {'pay' => 'daol'})
+      end
+    end
+  end
+end


### PR DESCRIPTION
An idea of how custom decoding/encoding of an JWT token could be handled. Related to #428 

Was thinking that custom decode modules could be created by including the JWT module into them. This included module could then provide a set of DSL methods where different handlers could be defined. For example:

```ruby
module MyCustomJWT
  include JWT

  algorithm 'HS256'

  decode_payload { |header, payload, signature| payload.reverse }
  encode_payload { |payload| payload.reverse }
end

payload = MyCustomJWT.encode({'pay' => 'load'}, key: 'secret')

decoded_data = MyCustomJWT.decode(payload, key: 'secret')
```

This approach would also make defining keyfinders and such much more elegant than passing everything to the `::JWT.decode` method

In this PR only a super simple `decode_payload` logic has been implemented as an illustration how it could work.