### PR TITLE
Raise a JWT::DecodeError when token is not a String

### DIFF
--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -9,7 +9,7 @@ module JWT
   # Decoding logic for JWT
   class Decode
     def initialize(jwt, key, verify, options, &keyfinder)
-      raise(JWT::DecodeError, 'Nil JSON web token') unless jwt
+      raise(JWT::DecodeError, "#{jwt.class} JSON web token") unless jwt.class == String
       @jwt = jwt
       @key = key
       @options = options

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -438,6 +438,13 @@ RSpec.describe JWT do
     end
   end
 
+  context 'when token is not a String' do
+    it 'raises JWT::DecodeError' do
+      expect { JWT.decode(nil, nil, true) }.to raise_error(JWT::DecodeError, 'NilClass JSON web token')
+      expect { JWT.decode(1, nil, true) }.to raise_error(JWT::DecodeError, 'Integer JSON web token')
+    end
+  end
+
   context 'a token with no segments' do
     it 'raises JWT::DecodeError' do
       expect { JWT.decode('ThisIsNotAValidJWTToken', nil, true) }.to raise_error(JWT::DecodeError, 'Not enough or too many segments')


### PR DESCRIPTION
Hello,

Currently when doing

```ruby
JWT.decode(nil, nil)
```
You get a `JWT::DecodeError (Nil JSON web token)`

or 

```ruby
JWT.decode('invalid', nil)
```
You get a `JWT::DecodeError (Not enough or too many segments)`

But we don't check for anything else than nil, everything else will supposedly fail at the `.split` in the `initialize`
e.g.
```ruby
JWT.decode(10, nil)
```
will give `NoMethodError (undefined method 'split' for 3:Integer)`

The only question is should this be the gem's responsibility to check that ? And if yes should we do the same with the secret (gives a `TypeError` which is slightly better)

PR is as close as possible from previous code to return a `JWT::DecodeError`