### PR TITLE
Remove context specific code from security utils

### DIFF
--- a/lib/jwt/algos/ecdsa.rb
+++ b/lib/jwt/algos/ecdsa.rb
@@ -21,7 +21,7 @@ module JWT
         end
 
         digest = OpenSSL::Digest.new(curve_definition[:digest])
-        SecurityUtils.asn1_to_raw(key.dsa_sign_asn1(digest.digest(msg)), key)
+        asn1_to_raw(key.dsa_sign_asn1(digest.digest(msg)), key)
       end
 
       def verify(to_verify)
@@ -32,18 +32,19 @@ module JWT
           raise IncorrectAlgorithm, "payload algorithm is #{algorithm} but #{key_algorithm} verification key was provided"
         end
         digest = OpenSSL::Digest.new(curve_definition[:digest])
-        public_key.dsa_verify_asn1(digest.digest(signing_input), SecurityUtils.raw_to_asn1(signature, public_key))
+        public_key.dsa_verify_asn1(digest.digest(signing_input), raw_to_asn1(signature, public_key))
       end
 
-      def curve_by_name(name)
-        algorithm = NAMED_CURVES.fetch(name) do
-          raise UnsupportedEcdsaCurve, "The ECDSA curve '#{name}' is not supported"
-        end
+      def asn1_to_raw(signature, public_key)
+        byte_size = (public_key.group.degree + 7) / 8
+        OpenSSL::ASN1.decode(signature).value.map { |value| value.value.to_s(2).rjust(byte_size, "\x00") }.join
+      end
 
-        {
-          algorithm: algorithm,
-          digest: algorithm.sub('ES', 'sha')
-        }
+      def raw_to_asn1(signature, private_key)
+        byte_size = (private_key.group.degree + 7) / 8
+        sig_bytes = signature[0..(byte_size - 1)]
+        sig_char = signature[byte_size..-1] || ''
+        OpenSSL::ASN1::Sequence.new([sig_bytes, sig_char].map { |int| OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(int, 2)) }).to_der
       end
     end
   end

--- a/lib/jwt/algos/ecdsa.rb
+++ b/lib/jwt/algos/ecdsa.rb
@@ -35,6 +35,17 @@ module JWT
         public_key.dsa_verify_asn1(digest.digest(signing_input), raw_to_asn1(signature, public_key))
       end
 
+      def curve_by_name(name)
+        algorithm = NAMED_CURVES.fetch(name) do
+          raise UnsupportedEcdsaCurve, "The ECDSA curve '#{name}' is not supported"
+        end
+
+        {
+          algorithm: algorithm,
+          digest: algorithm.sub('ES', 'sha')
+        }
+      end
+
       def asn1_to_raw(signature, public_key)
         byte_size = (public_key.group.degree + 7) / 8
         OpenSSL::ASN1.decode(signature).value.map { |value| value.value.to_s(2).rjust(byte_size, "\x00") }.join

--- a/lib/jwt/algos/ps.rb
+++ b/lib/jwt/algos/ps.rb
@@ -24,7 +24,13 @@ module JWT
       def verify(to_verify)
         require_openssl!
 
-        SecurityUtils.verify_ps(to_verify.algorithm, to_verify.public_key, to_verify.signing_input, to_verify.signature)
+        formatted_algorithm = to_verify.algorithm.sub('PS', 'sha')
+
+        to_verify.public_key.verify_pss(formatted_algorithm,
+          to_verify.signature,
+          to_verify.signing_input,
+          salt_length: :auto,
+          mgf1_hash: formatted_algorithm)
       end
 
       def require_openssl!

--- a/lib/jwt/algos/ps.rb
+++ b/lib/jwt/algos/ps.rb
@@ -27,10 +27,10 @@ module JWT
         formatted_algorithm = to_verify.algorithm.sub('PS', 'sha')
 
         to_verify.public_key.verify_pss(formatted_algorithm,
-          to_verify.signature,
-          to_verify.signing_input,
-          salt_length: :auto,
-          mgf1_hash: formatted_algorithm)
+                                        to_verify.signature,
+                                        to_verify.signing_input,
+                                        salt_length: :auto,
+                                        mgf1_hash: formatted_algorithm)
       end
 
       def require_openssl!

--- a/lib/jwt/algos/rsa.rb
+++ b/lib/jwt/algos/rsa.rb
@@ -12,7 +12,7 @@ module JWT
       end
 
       def verify(to_verify)
-        SecurityUtils.verify_rsa(to_verify.algorithm, to_verify.public_key, to_verify.signing_input, to_verify.signature)
+        to_verify.public_key.verify(OpenSSL::Digest.new(to_verify.algorithm.sub('RS', 'sha')), to_verify.signature, to_verify.signing_input)
       end
     end
   end

--- a/lib/jwt/security_utils.rb
+++ b/lib/jwt/security_utils.rb
@@ -33,21 +33,5 @@ module JWT
       sig_char = signature[byte_size..-1] || ''
       OpenSSL::ASN1::Sequence.new([sig_bytes, sig_char].map { |int| OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(int, 2)) }).to_der
     end
-
-    def rbnacl_fixup(algorithm, key)
-      algorithm = algorithm.sub('HS', 'SHA').to_sym
-
-      return [] unless defined?(RbNaCl) && RbNaCl::HMAC.constants(false).include?(algorithm)
-
-      authenticator = RbNaCl::HMAC.const_get(algorithm)
-
-      # Fall back to OpenSSL for keys larger than 32 bytes.
-      return [] if key.bytesize > authenticator.key_bytes
-
-      [
-        authenticator,
-        key.bytes.fill(0, key.bytesize...authenticator.key_bytes).pack('C*')
-      ]
-    end
   end
 end

--- a/lib/jwt/security_utils.rb
+++ b/lib/jwt/security_utils.rb
@@ -15,11 +15,5 @@ module JWT
       right.each_byte { |byte| result |= byte ^ unpacked_left.shift }
       result.zero?
     end
-
-    def verify_ps(algorithm, public_key, signing_input, signature)
-      formatted_algorithm = algorithm.sub('PS', 'sha')
-
-      public_key.verify_pss(formatted_algorithm, signature, signing_input, salt_length: :auto, mgf1_hash: formatted_algorithm)
-    end
   end
 end

--- a/lib/jwt/security_utils.rb
+++ b/lib/jwt/security_utils.rb
@@ -2,6 +2,8 @@ module JWT
   # Collection of security methods
   #
   # @see: https://github.com/rails/rails/blob/master/activesupport/lib/active_support/security_utils.rb
+
+  # rubocop:disable Naming/MethodParameterName
   module SecurityUtils
     if defined?(OpenSSL.fixed_length_secure_compare)
       def fixed_length_secure_compare(a, b)
@@ -26,4 +28,6 @@ module JWT
     end
     module_function :secure_compare
   end
+
+  # rubocop:enable Naming/MethodParameterName
 end

--- a/lib/jwt/security_utils.rb
+++ b/lib/jwt/security_utils.rb
@@ -16,10 +16,6 @@ module JWT
       result.zero?
     end
 
-    def verify_rsa(algorithm, public_key, signing_input, signature)
-      public_key.verify(OpenSSL::Digest.new(algorithm.sub('RS', 'sha')), signature, signing_input)
-    end
-
     def verify_ps(algorithm, public_key, signing_input, signature)
       formatted_algorithm = algorithm.sub('PS', 'sha')
 

--- a/lib/jwt/security_utils.rb
+++ b/lib/jwt/security_utils.rb
@@ -21,17 +21,5 @@ module JWT
 
       public_key.verify_pss(formatted_algorithm, signature, signing_input, salt_length: :auto, mgf1_hash: formatted_algorithm)
     end
-
-    def asn1_to_raw(signature, public_key)
-      byte_size = (public_key.group.degree + 7) / 8
-      OpenSSL::ASN1.decode(signature).value.map { |value| value.value.to_s(2).rjust(byte_size, "\x00") }.join
-    end
-
-    def raw_to_asn1(signature, private_key)
-      byte_size = (private_key.group.degree + 7) / 8
-      sig_bytes = signature[0..(byte_size - 1)]
-      sig_char = signature[byte_size..-1] || ''
-      OpenSSL::ASN1::Sequence.new([sig_bytes, sig_char].map { |int| OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(int, 2)) }).to_der
-    end
   end
 end


### PR DESCRIPTION
The `JWT::SecurityUtils` module has over the years been used as a placeholder for context specific methods.

This PR moves the "utility" methods into the context they actually are used from.

Also updated the SecureUtils.secure_compare to take advantage of the latest optimisations available.