### PR TITLE
fix document about passing JWKs as a simple Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ end
 or by passing JWK as a simple Hash
 
 ```
-jwks = { keys: [{ ... }] } # keys needs to be Symbol
+jwks = { keys: [{ ... }] } # keys accepts both of string and symbol
 JWT.decode(token, nil, true, { algorithms: ['RS512'], jwks: jwks})
 ```
 


### PR DESCRIPTION
Hi.

I found a gap between documentation and implementation.

document: https://github.com/jwt/ruby-jwt/pull/341
implementation: https://github.com/jwt/ruby-jwt/pull/348