### PR TITLE
Pass kid param through JWT::JWK.create_from

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ JWT.decode token, hmac_secret, true, { required_claims: ['exp'], algorithm: 'HS2
 JWK is a JSON structure representing a cryptographic key. Currently only supports RSA public keys.
 
 ```ruby
-jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048))
+jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048), "optional-kid")
 payload, headers = { data: 'data' }, { kid: jwk.kid }
 
 token = JWT.encode(payload, jwk.keypair, 'RS512', headers)

--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -14,10 +14,10 @@ module JWT
         end.import(jwk_data)
       end
 
-      def create_from(keypair)
+      def create_from(keypair, kid = nil)
         mappings.fetch(keypair.class) do |klass|
           raise JWT::JWKError, "Cannot create JWK from a #{klass.name}"
-        end.new(keypair)
+        end.new(keypair, kid)
       end
 
       def classes

--- a/spec/jwk_spec.rb
+++ b/spec/jwk_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe JWT::JWK do
   end
 
   describe '.new' do
-    subject { described_class.new(keypair) }
+    let(:kid) { nil }
+    subject { described_class.new(keypair, kid) }
 
     context 'when RSA key is given' do
       let(:keypair) { rsa_key }
@@ -56,6 +57,14 @@ RSpec.describe JWT::JWK do
     context 'when EC key is given' do
       let(:keypair) { ec_key }
       it { is_expected.to be_a ::JWT::JWK::EC }
+    end
+
+    context 'when kid is given' do
+      let(:keypair) { rsa_key }
+      let(:kid) { "CUSTOM_KID" }
+      it 'sets the kid' do
+        expect(subject.kid).to eq(kid)
+      end
     end
   end
 end


### PR DESCRIPTION
The underlying keypair classes already support an optional second parameter for the key id; however, the JWT::JWK interface didn't provide any mechanism for setting them via the constructor.