### PR TITLE
Fix openssl gem version check to support versons greater than 3

### DIFF
--- a/lib/jwt/algos/ps.rb
+++ b/lib/jwt/algos/ps.rb
@@ -29,9 +29,7 @@ module JWT
 
       def require_openssl!
         if Object.const_defined?('OpenSSL')
-          major, minor = OpenSSL::VERSION.split('.').first(2)
-
-          unless major.to_i >= 2 && minor.to_i >= 1
+          if ::Gem::Version.new(OpenSSL::VERSION) < ::Gem::Version.new('2.1')
             raise JWT::RequiredDependencyError, "You currently have OpenSSL #{OpenSSL::VERSION}. PS support requires >= 2.1"
           end
         else


### PR DESCRIPTION
This will fix compatibility problems with Ruby 3.1 (ref: https://github.com/jwt/ruby-jwt/runs/4236991920?check_suite_focus=true)