### PR TITLE
Stop running tests on EOL rubies.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.4"
+        ruby-version: "2.6"
         bundler-cache: true
     - name: Run RuboCop
       run: bundle exec rubocop
@@ -26,9 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.3
-          - 2.4
-          - 2.5
           - 2.6
           - 2.7
           - "3.0"
@@ -38,12 +35,6 @@ jobs:
           - gemfiles/rbnacl.gemfile
         experimental: [false]
         include:
-          - ruby: 2.1
-            gemfile: 'gemfiles/rbnacl.gemfile'
-            experimental: false
-          - ruby: 2.2
-            gemfile: 'gemfiles/rbnacl.gemfile'
-            experimental: false
           - ruby: 2.7
             coverage: "true"
             gemfile: 'gemfiles/rbnacl.gemfile'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.1
 
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 

--- a/ruby-jwt.gemspec
+++ b/ruby-jwt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description = 'A pure ruby implementation of the RFC 7519 OAuth JSON Web Token (JWT) standard.'
   spec.homepage = 'https://github.com/jwt/ruby-jwt'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.6'
   spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/jwt/ruby-jwt/issues',
     'changelog_uri'   => "https://github.com/jwt/ruby-jwt/blob/v#{JWT.gem_version}/CHANGELOG.md"


### PR DESCRIPTION
I think it's time to move forward. Drop the support for EOLed rubies in the next (2.4?) release.
