### PR TITLE
Bring back Ruby 2.5 support and CodeClimate coverage reports

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+---
+name: coverage
+on:
+  push:
+    branches:
+      - "master"
+jobs:
+ coverage:
+    name: coverage
+    runs-on: ubuntu-20.04
+    env:
+      BUNDLE_GEMFILE: 'gemfiles/rbnacl.gemfile'
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install libsodium
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install libsodium-dev -y
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7"
+          bundler-cache: true
+      - uses: paambaati/codeclimate-action@v3.0.0
+        with:
+          coverageCommand: bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.6"
+        ruby-version: "2.7"
         bundler-cache: true
     - name: Run RuboCop
       run: bundle exec rubocop
@@ -26,6 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - 2.5
           - 2.6
           - 2.7
           - "3.0"
@@ -37,7 +38,6 @@ jobs:
         experimental: [false]
         include:
           - ruby: 2.7
-            coverage: "true"
             gemfile: 'gemfiles/rbnacl.gemfile'
           - ruby: "ruby-head"
             experimental: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.5
   NewCops: enable
   SuggestExtensions: false
   Exclude:

--- a/ruby-jwt.gemspec
+++ b/ruby-jwt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description = 'A pure ruby implementation of the RFC 7519 OAuth JSON Web Token (JWT) standard.'
   spec.homepage = 'https://github.com/jwt/ruby-jwt'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.5'
   spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/jwt/ruby-jwt/issues',
     'changelog_uri'   => "https://github.com/jwt/ruby-jwt/blob/v#{JWT.gem_version}/CHANGELOG.md"


### PR DESCRIPTION
Think we should take one step back in dropping older Ruby support, keeping the EOLed 2.5 support until it adds some problems for us. The gem works just fine with 2.5, no new fancy feature taken into use.

Also this PR brings back CodeClimate coverage reports.

