### PR TITLE
Update note about supported JWK types

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ end
 
 ### JSON Web Key (JWK)
 
-JWK is a JSON structure representing a cryptographic key. Currently only supports RSA public keys.
+JWK is a JSON structure representing a cryptographic key. Currently only supports RSA, EC and HMAC keys.
 
 ```ruby
 jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048), "optional-kid")


### PR DESCRIPTION
Earlier statement about only supporting RSA was outdated and misleading.
There is now support for RSA, EC and HMAC (https://github.com/jwt/ruby-jwt/tree/master/lib/jwt/jwk)