### PR TITLE
fix(JWT::decode): raise JWT::DecodeError on invalid signature

### DIFF
--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -118,6 +118,8 @@ module JWT
 
     def decode_crypto
       @signature = Base64.urlsafe_decode64(@segments[2] || '')
+    rescue ArgumentError
+      raise(JWT::DecodeError, 'Invalid segment encoding')
     end
 
     def algorithm

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -575,6 +575,12 @@ RSpec.describe JWT do
     end
   end
 
+  context 'a token with invalid Base64 segments' do
+    it 'raises JWT::DecodeError' do
+      expect { JWT.decode('hello.there.world') }.to raise_error(JWT::DecodeError, 'Invalid segment encoding')
+    end
+  end
+
   context 'a token with two segments but does not require verifying' do
     it 'raises something else than "Not enough or too many segments"' do
       expect { JWT.decode('ThisIsNotAValidJWTToken.second', nil, false) }.to raise_error(JWT::DecodeError, 'Invalid segment encoding')


### PR DESCRIPTION
Resolves https://github.com/jwt/ruby-jwt/issues/483