### PR TITLE
Bring back the custom Base64 deocde mechanisms

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'base64'
+require 'jwt/base64'
 require 'jwt/json'
 require 'jwt/decode'
 require 'jwt/default_options'

--- a/lib/jwt/base64.rb
+++ b/lib/jwt/base64.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'base64'
+
+module JWT
+  # Base64 helpers
+  class Base64
+    class << self
+      def url_encode(str)
+        ::Base64.encode64(str).tr('+/', '-_').gsub(/[\n=]/, '')
+      end
+
+      def url_decode(str)
+        str += '=' * (4 - str.length.modulo(4))
+        ::Base64.decode64(str.tr('-_', '+/'))
+      end
+    end
+  end
+end

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -117,9 +117,7 @@ module JWT
     end
 
     def decode_crypto
-      @signature = Base64.urlsafe_decode64(@segments[2] || '')
-    rescue ArgumentError
-      raise(JWT::DecodeError, 'Invalid segment encoding')
+      @signature = ::JWT::Base64.url_decode(@segments[2] || '')
     end
 
     def algorithm
@@ -139,8 +137,8 @@ module JWT
     end
 
     def parse_and_decode(segment)
-      JWT::JSON.parse(Base64.urlsafe_decode64(segment))
-    rescue ::JSON::ParserError, ArgumentError
+      JWT::JSON.parse(::JWT::Base64.url_decode(segment))
+    rescue ::JSON::ParserError
       raise JWT::DecodeError, 'Invalid segment encoding'
     end
   end

--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -55,11 +55,11 @@ module JWT
     def encode_signature
       return '' if @algorithm == ALG_NONE
 
-      Base64.urlsafe_encode64(JWT::Signature.sign(@algorithm, encoded_header_and_payload, @key), padding: false)
+      ::JWT::Base64.url_encode(JWT::Signature.sign(@algorithm, encoded_header_and_payload, @key))
     end
 
     def encode(data)
-      Base64.urlsafe_encode64(JWT::JSON.generate(data), padding: false)
+      ::JWT::Base64.url_encode(JWT::JSON.generate(data))
     end
 
     def combine(*parts)

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -75,11 +75,11 @@ module JWT
       end
 
       def encode_octets(octets)
-        Base64.urlsafe_encode64(octets, padding: false)
+        ::JWT::Base64.url_encode(octets)
       end
 
       def encode_open_ssl_bn(key_part)
-        Base64.urlsafe_encode64(key_part.to_s(BINARY), padding: false)
+        ::JWT::Base64.url_encode(key_part.to_s(BINARY))
       end
 
       class << self
@@ -142,11 +142,11 @@ module JWT
         end
 
         def decode_octets(jwk_data)
-          Base64.urlsafe_decode64(jwk_data)
+          ::JWT::Base64.url_decode(jwk_data)
         end
 
         def decode_open_ssl_bn(jwk_data)
-          OpenSSL::BN.new(Base64.urlsafe_decode64(jwk_data), BINARY)
+          OpenSSL::BN.new(::JWT::Base64.url_decode(jwk_data), BINARY)
         end
       end
     end

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -55,7 +55,7 @@ module JWT
       end
 
       def encode_open_ssl_bn(key_part)
-        Base64.urlsafe_encode64(key_part.to_s(BINARY), padding: false)
+        ::JWT::Base64.url_encode(key_part.to_s(BINARY))
       end
 
       class << self
@@ -108,7 +108,7 @@ module JWT
         def decode_open_ssl_bn(jwk_data)
           return nil unless jwk_data
 
-          OpenSSL::BN.new(Base64.urlsafe_decode64(jwk_data), BINARY)
+          OpenSSL::BN.new(::JWT::Base64.url_decode(jwk_data), BINARY)
         end
       end
     end

--- a/lib/jwt/x5c_key_finder.rb
+++ b/lib/jwt/x5c_key_finder.rb
@@ -47,7 +47,7 @@ module JWT
         x5c_header_or_certificates
       else
         x5c_header_or_certificates.map do |encoded|
-          OpenSSL::X509::Certificate.new(::Base64.strict_decode64(encoded))
+          OpenSSL::X509::Certificate.new(::JWT::Base64.url_decode(encoded))
         end
       end
     end

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe JWT do
           translated_alg  = alg.gsub('PS', 'sha')
           valid_signature = data[:rsa_public].verify_pss(
             translated_alg,
-            Base64.urlsafe_decode64(signature),
+            ::JWT::Base64.url_decode(signature),
             [header, body].join('.'),
             salt_length: :auto,
             mgf1_hash: translated_alg
@@ -611,7 +611,7 @@ RSpec.describe JWT do
 
   context 'when the alg value is given as a header parameter' do
     it 'does not override the actual algorithm used' do
-      headers = JSON.parse(Base64.urlsafe_decode64(JWT.encode('Hello World', 'secret', 'HS256', { alg: 'HS123' }).split('.').first))
+      headers = JSON.parse(::JWT::Base64.url_decode(JWT.encode('Hello World', 'secret', 'HS256', { alg: 'HS123' }).split('.').first))
       expect(headers['alg']).to eq('HS256')
     end
 


### PR DESCRIPTION
This brings back the Base64 decoding based on RFC 2045 (not strict)

Fixes #487