### PR TITLE
Test for decode behaviour with non-alphabetic chars in base64

### DIFF
--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -755,4 +755,11 @@ RSpec.describe JWT do
       expect { ::JWT.decode(no_key_token, nil, true, algorithms: 'HS512') }.to raise_error(JWT::DecodeError, 'No verification key available')
     end
   end
+
+  context 'when token ends with a newline char' do
+    let(:token) { "#{JWT.encode(payload, 'secret', 'HS256')}\n" }
+    it 'ignores the newline and decodes the token' do
+      expect(JWT.decode(token, 'secret', true, algorithm: 'HS256')).to include(payload)
+    end
+  end
 end


### PR DESCRIPTION
Added a test to document the behaviour of the decode method when tokens including some non-alphabetic chars are given.
