### PR TITLE
Improved RSA signing and verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 **Fixes and enhancements:**
 
+- Improved RSA algorithm [#494](https://github.com/jwt/ruby-jwt/pull/494) ([@anakinj](https://github.com/anakinj)).
 - Your contribution here
 
 ## [v2.5.0](https://github.com/jwt/ruby-jwt/tree/v2.5.0) (2022-08-25)

--- a/lib/jwt/security_utils.rb
+++ b/lib/jwt/security_utils.rb
@@ -18,10 +18,6 @@ module JWT
       result.zero?
     end
 
-    def verify_rsa(algorithm, public_key, signing_input, signature)
-      public_key.verify(OpenSSL::Digest.new(algorithm.sub('RS', 'sha')), signature, signing_input)
-    end
-
     def verify_ps(algorithm, public_key, signing_input, signature)
       formatted_algorithm = algorithm.sub('PS', 'sha')
 

--- a/spec/jwk/decode_with_jwk_spec.rb
+++ b/spec/jwk/decode_with_jwk_spec.rb
@@ -127,17 +127,7 @@ RSpec.describe JWT do
 
         it 'fails in some way' do
           expect { described_class.decode(signed_token, nil, true, algorithms: ['RS512'], jwks: jwks) }.to(
-            raise_error(JWT::VerificationError, 'Signature verification raised')
-          )
-        end
-      end
-
-      context 'when HMAC secret is pointed to as RSA public key' do
-        let(:signed_token) { described_class.encode({ 'foo' => 'bar' }, rsa_jwk.keypair, 'RS512', { kid: hmac_jwk.kid }) }
-
-        it 'fails in some way' do
-          expect { described_class.decode(signed_token, nil, true, algorithms: ['RS512'], jwks: jwks) }.to(
-            raise_error(NoMethodError, /undefined method `verify' for "secret":String/)
+            raise_error(JWT::VerificationError)
           )
         end
       end

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -771,4 +771,24 @@ RSpec.describe JWT do
       expect(JWT.decode(token, 'secret', true, algorithm: 'HS256')).to include(payload)
     end
   end
+
+  context 'when RSA key is given as a String on encoding' do
+    it 'raises a ::JWT::EncodeError' do
+      expect { JWT.encode(payload, 'secret', 'RS256') }.to raise_error(::JWT::EncodeError, 'The given key is a String. It has to be an OpenSSL::PKey::RSA instance.')
+    end
+  end
+
+  context 'when RSA key is given as a Integer on encoding' do
+    it 'raises a ::JWT::EncodeError' do
+      expect { JWT.encode(payload, 123, 'RS256') }.to raise_error(::JWT::EncodeError, 'The given key is a Integer. It has to be an OpenSSL::PKey::RSA instance.')
+    end
+  end
+
+  context 'when RSA key is given as a String on decoding' do
+    let(:token) { JWT.encode(payload, OpenSSL::PKey::RSA.new(2048), 'RS256') }
+
+    it 'raises a ::JWT::DecodeError' do
+      expect { JWT.decode(token, 'secret', true, algorithm: 'RS256') }.to raise_error(::JWT::DecodeError, 'The given key is a String. It has to be an OpenSSL::PKey::RSA instance.')
+    end
+  end
 end


### PR DESCRIPTION
Some improvements for the RSA algorithm:
- One step closer to get rid of the algorithm specific methods from `::JWT:SecurityUtils` (Something that was started on #442)
- Stricter requirements for the RSA key on both signing and verification. 
- Simpler resolving of the digests per algorithm