### PR TITLE
Fix NoMethodError when a 2 segment token is missing 'alg' header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bring back the old Base64 (RFC2045) deocode mechanisms [#488](https://github.com/jwt/ruby-jwt/pull/488) ([@anakinj](https://github.com/anakinj)).
 - Rescue RbNaCl exception for EdDSA wrong key [#491](https://github.com/jwt/ruby-jwt/pull/491) ([@n-studio](https://github.com/n-studio)).
 - New parameter name for cases when kid is not found using JWK key loader proc [#501](https://github.com/jwt/ruby-jwt/pull/501) ([@anakinj](https://github.com/anakinj)).
+- Fix NoMethodError when a 2 segment token is missing 'alg' header [#502](https://github.com/jwt/ruby-jwt/pull/502) ([@cmrd-senya](https://github.com/cmrd-senya)).
 - Your contribution here
 
 ## [v2.4.1](https://github.com/jwt/ruby-jwt/tree/v2.4.1) (2022-06-07)

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -113,7 +113,7 @@ module JWT
     end
 
     def none_algorithm?
-      algorithm.casecmp('none').zero?
+      algorithm == 'none'
     end
 
     def decode_crypto

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe JWT do
   let :data do
     data = {
       :empty_token => 'e30K.e30K.e30K',
+      :empty_token_2_segment => 'e30K.e30K.',
       :secret => 'My$ecretK3y',
       :rsa_private => OpenSSL::PKey.read(File.read(File.join(CERT_PATH, 'rsa-2048-private.pem'))),
       :rsa_public => OpenSSL::PKey.read(File.read(File.join(CERT_PATH, 'rsa-2048-public.pem'))),
@@ -536,6 +537,14 @@ RSpec.describe JWT do
           expect do
             JWT.decode data[:empty_token]
           end.to raise_error JWT::IncorrectAlgorithm
+        end
+
+        context '2-segment token' do
+          it 'should raise JWT::IncorrectAlgorithm' do
+            expect do
+              JWT.decode data[:empty_token_2_segment]
+            end.to raise_error JWT::DecodeError
+          end
         end
       end
     end


### PR DESCRIPTION
This PR fixes an issue that was introduced at https://github.com/jwt/ruby-jwt/pull/425

Currently if one passes a token of 2 segments without `alg` header the `decode` method raises `NoMethorError` because `algorithm` is `nil` but it tries to call `casecmp` on it here:
https://github.com/jwt/ruby-jwt/blob/master/lib/jwt/decode.rb#L116

The expected result would be to raise an exception that is inherited from `JWT::DecodeError` instead of a generic exception like `NoMethodError`.