### PR TITLE
Explicit loading of jwt/version to make it available for a built gem

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'jwt/version'
 require 'jwt/base64'
 require 'jwt/json'
 require 'jwt/decode'


### PR DESCRIPTION
The version file is not loaded when the gem is loading, the .gemspec is not evaluated in a built gem as it is when testing the gem. This means that the things defined in the version.rb file has not been availabe in released gems. This PR should fix that issue.