### PR TITLE
set rubygems_mfa_required to true for gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,3 @@ Layout/MultilineOperationIndentation:
 
 Style/WordArray:
   Enabled: false
-
-Gemspec/RequireMFA:
-  Enabled: false

--- a/ruby-jwt.gemspec
+++ b/ruby-jwt.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5'
   spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/jwt/ruby-jwt/issues',
-    'changelog_uri' => "https://github.com/jwt/ruby-jwt/blob/v#{JWT.gem_version}/CHANGELOG.md"
+    'changelog_uri' => "https://github.com/jwt/ruby-jwt/blob/v#{JWT.gem_version}/CHANGELOG.md",
+    'rubygems_mfa_required' => 'true'
   }
 
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|gemfiles|coverage|bin)/}) }


### PR DESCRIPTION
MFA is required to publish this gem nowadays.