### PR TITLE
Exclude files not relevant for release

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,7 @@ Metrics/MethodLength:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*_spec.rb
+    - '*.gemspec'
 
 Layout/LineLength:
   Enabled: false

--- a/ruby-jwt.gemspec
+++ b/ruby-jwt.gemspec
@@ -22,7 +22,12 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|gemfiles|coverage|bin)/}) }
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(spec|gemfiles|coverage|bin)/}) || # Irrelevant folders
+      f.match(/^\.+/) || # Files and folders starting with .
+      f.match(/^(Appraisals|Gemfile|Rakefile)$/) # Irrelevant files
+  end
+
   spec.executables = []
   spec.require_paths = %w[lib]
 


### PR DESCRIPTION
Noticed that the built gem contains a few files that is not needed for the gem to function. This PR:

- Exclude everything starting with `.` from the package
- Exclude Rakefile, Gemfile and Appraisals