### PR TITLE
Stricter RSA key generation from jwk parameters

### DIFF
--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -10,6 +10,9 @@ module JWT
       RSA_PRIVATE_KEY_ELEMENTS = %i[d p q dp dq qi].freeze
       RSA_KEY_ELEMENTS = (RSA_PRIVATE_KEY_ELEMENTS + RSA_PUBLIC_KEY_ELEMENTS).freeze
 
+      RSA_OPT_PARAMS    = %i[p q dp dq qi].freeze
+      RSA_ASN1_SEQUENCE = (%i[n e d] + RSA_OPT_PARAMS).freeze # https://www.rfc-editor.org/rfc/rfc3447#appendix-A.1.2
+
       def initialize(key, params = nil, options = {})
         params ||= {}
 
@@ -122,9 +125,6 @@ module JWT
 
           OpenSSL::BN.new(::JWT::Base64.url_decode(jwk_data), BINARY)
         end
-
-        RSA_OPT_PARAMS    = %i[p q dp dq qi].freeze
-        RSA_ASN1_SEQUENCE = (%i[n e d] + RSA_OPT_PARAMS).freeze # https://www.rfc-editor.org/rfc/rfc3447#appendix-A.1.2
 
         def create_rsa_key_using_der(rsa_parameters)
           validate_rsa_parameters!(rsa_parameters)

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -168,10 +168,10 @@ module JWT
         end
 
         def validate_rsa_parameters!(rsa_parameters)
-          return unless rsa_parameters[:d]
+          return unless rsa_parameters.key?(:d)
 
-          return if RSA_OPT_PARAMS.all? { |k| rsa_parameters.keys.include?(k) }
-          return if RSA_OPT_PARAMS.none? { |k| rsa_parameters.keys.include?(k) }
+          parameters = RSA_OPT_PARAMS - rsa_parameters.keys
+          return if parameters.empty? || parameters.size == RSA_OPT_PARAMS.size
 
           raise JWT::JWKError, 'When one of p, q, dp, dq or qi is given all the other optimization parameters also needs to be defined' # https://www.rfc-editor.org/rfc/rfc7518.html#section-6.3.2
         end

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -137,6 +137,8 @@ module JWT
 
           if sequence.size > 2 # Append "two-prime" version for private key
             sequence.unshift(OpenSSL::ASN1::Integer.new(0))
+
+            raise JWT::JWKError, 'Creating a RSA key with a private key requires the CRT parameters to be defined' if sequence.size < RSA_ASN1_SEQUENCE.size
           end
 
           OpenSSL::PKey::RSA.new(OpenSSL::ASN1::Sequence(sequence).to_der)

--- a/lib/jwt/version.rb
+++ b/lib/jwt/version.rb
@@ -27,6 +27,10 @@ module JWT
   end
 
   def self.openssl_3_hmac_empty_key_regression?
-    openssl_3? && ::Gem::Version.new(OpenSSL::VERSION) <= ::Gem::Version.new('3.0.0')
+    openssl_3? && openssl_version <= ::Gem::Version.new('3.0.0')
+  end
+
+  def self.openssl_version
+    @openssl_version ||= ::Gem::Version.new(OpenSSL::VERSION)
   end
 end

--- a/spec/jwk/rsa_spec.rb
+++ b/spec/jwk/rsa_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe JWT::JWK::RSA do
     end
   end
 
-  shared_examples 'creating RSA object from partial JWK parameters' do
+  shared_examples 'creating an RSA object from partial JWK parameters' do
     context 'when e, n, d is given' do
       let(:jwk_parameters) { all_jwk_parameters.slice(:e, :n, :d) }
 
@@ -194,19 +194,26 @@ RSpec.describe JWT::JWK::RSA do
     include_examples 'creating an RSA object from complete JWK parameters'
   end
 
-  if OpenSSL::PKey::RSA.new.respond_to?(:set_key) # Very old OpenSSL versions (pre 1.1.0)
-    describe '.create_rsa_key_using_sets' do
-      subject(:rsa) { described_class.create_rsa_key_using_sets(rsa_parameters) }
-
-      include_examples 'creating an RSA object from complete JWK parameters'
-      include_examples 'creating RSA object from partial JWK parameters'
+  describe '.create_rsa_key_using_sets' do
+    before do
+      skip unless OpenSSL::PKey::RSA.new.respond_to?(:set_key)
+      skip if ::JWT.openssl_3?
     end
-  elsif !::JWK.openssl_3?
-    describe '.create_rsa_key_using_accessors' do
-      subject(:rsa) { described_class.create_rsa_key_using_accessors(rsa_parameters) }
 
-      include_examples 'creating an RSA object from complete JWK parameters'
-      include_examples 'creating RSA object from partial JWK parameters'
+    subject(:rsa) { described_class.create_rsa_key_using_sets(rsa_parameters) }
+
+    include_examples 'creating an RSA object from complete JWK parameters'
+    include_examples 'creating an RSA object from partial JWK parameters'
+  end
+
+  describe '.create_rsa_key_using_accessors' do
+    before do
+      skip if OpenSSL::PKey::RSA.new.respond_to?(:set_key)
     end
+
+    subject(:rsa) { described_class.create_rsa_key_using_accessors(rsa_parameters) }
+
+    include_examples 'creating an RSA object from complete JWK parameters'
+    include_examples 'creating an RSA object from partial JWK parameters'
   end
 end

--- a/spec/jwk/rsa_spec.rb
+++ b/spec/jwk/rsa_spec.rb
@@ -196,6 +196,14 @@ RSpec.describe JWT::JWK::RSA do
     subject(:rsa) { described_class.create_rsa_key_using_der(rsa_parameters) }
 
     include_examples 'creating an RSA object from complete JWK parameters'
+
+    context 'when e, n, d is given' do
+      let(:jwk_parameters) { all_jwk_parameters.slice(:e, :n, :d) }
+
+      it 'expects all CRT parameters given and raises error' do
+        expect { subject }.to raise_error(JWT::JWKError, 'Creating a RSA key with a private key requires the CRT parameters to be defined')
+      end
+    end
   end
 
   describe '.create_rsa_key_using_sets' do

--- a/spec/jwk/rsa_spec.rb
+++ b/spec/jwk/rsa_spec.rb
@@ -171,6 +171,10 @@ RSpec.describe JWT::JWK::RSA do
     context 'when e, n, d is given' do
       let(:jwk_parameters) { all_jwk_parameters.slice(:e, :n, :d) }
 
+      before do
+        skip 'OpenSSL prior to 2.2 does not seem to support partial parameters' if ::JWT.openssl_version < ::Gem::Version.new('2.2')
+      end
+
       it 'creates a valid RSA object representing a private key' do
         expect(subject).to be_a(::OpenSSL::PKey::RSA)
         expect(subject.private?).to eq(true)
@@ -196,8 +200,8 @@ RSpec.describe JWT::JWK::RSA do
 
   describe '.create_rsa_key_using_sets' do
     before do
-      skip unless OpenSSL::PKey::RSA.new.respond_to?(:set_key)
-      skip if ::JWT.openssl_3?
+      skip 'OpenSSL without the RSA#set_key method not supported' unless OpenSSL::PKey::RSA.new.respond_to?(:set_key)
+      skip 'OpenSSL 3.0 does not allow mutating objects anymore' if ::JWT.openssl_3?
     end
 
     subject(:rsa) { described_class.create_rsa_key_using_sets(rsa_parameters) }
@@ -208,7 +212,7 @@ RSpec.describe JWT::JWK::RSA do
 
   describe '.create_rsa_key_using_accessors' do
     before do
-      skip if OpenSSL::PKey::RSA.new.respond_to?(:set_key)
+      skip 'OpenSSL if RSA#set_key is available there is no accessors anymore' if OpenSSL::PKey::RSA.new.respond_to?(:set_key)
     end
 
     subject(:rsa) { described_class.create_rsa_key_using_accessors(rsa_parameters) }


### PR DESCRIPTION
This PR is addressing a parts of #523 and adding test coverage on a few scenarios. 

Moved the methods around a little for easier testing and added parameter validation with the rule:
 - If one of the optimisation params are given ALL needs to be given

As you @bellebaum pointed out the DER generation has some issues when parameters are missing. Did not dig that deep but I have a feeling that there is no way to present a private key in the DER format without these parameters.

Im a little unsure what do, not really eager into starting to calculate the primes etc. I guess it's doable but feels sketchy. 

So I guess the question is:

Is there a way to generate a usable RSA object with OpenSSL 3.0 with only the modulus and exponents (n,e,d)? as the JWK spec allows private keys to be presented with only these values.
