### PR TITLE
Add a JWKS implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Support custom algorithms by passing algorithm objects[#512](https://github.com/jwt/ruby-jwt/pull/512) ([@anakinj](https://github.com/anakinj)).
 - Support descriptive (not key related) JWK parameters[#520](https://github.com/jwt/ruby-jwt/pull/520) ([@bellebaum](https://github.com/bellebaum)).
+- Support for JSON Web Key Sets[#525](https://github.com/jwt/ruby-jwt/pull/525) ([@bellebaum](https://github.com/bellebaum)).
 - Your contribution here
 
 **Fixes and enhancements:**

--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'jwk/key_finder'
+require_relative 'jwk/set'
 
 module JWT
   module JWK

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -9,7 +9,7 @@ module JWT
       def_delegators :keypair, :public_key
 
       KTY    = 'EC'
-      KTYS   = [KTY, OpenSSL::PKey::EC].freeze
+      KTYS   = [KTY, OpenSSL::PKey::EC, JWT::JWK::EC].freeze
       BINARY = 2
       EC_PUBLIC_KEY_ELEMENTS = %i[kty crv x y].freeze
       EC_PRIVATE_KEY_ELEMENTS = %i[d].freeze

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -22,6 +22,8 @@ module JWT
         params = { kid: params } if params.is_a?(String)
 
         key_params = case key
+                     when JWT::JWK::EC
+                       key.export(include_private: true)
                      when OpenSSL::PKey::EC # Accept OpenSSL key as input
                        @keypair = key # Preserve the object to avoid recreation
                        parse_ec_key(key)

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -16,6 +16,8 @@ module JWT
         params = { kid: params } if params.is_a?(String)
 
         key_params = case key
+                     when JWT::JWK::HMAC
+                       key.export(include_private: true)
                      when String # Accept String key as input
                        { kty: KTY, k: key }
                      when Hash

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -15,16 +15,7 @@ module JWT
         # For backwards compatibility when kid was a String
         params = { kid: params } if params.is_a?(String)
 
-        key_params = case key
-                     when JWT::JWK::HMAC
-                       key.export(include_private: true)
-                     when String # Accept String key as input
-                       { kty: KTY, k: key }
-                     when Hash
-                       key.transform_keys(&:to_sym)
-                     else
-                       raise ArgumentError, 'key must be of type String or Hash with key parameters'
-        end
+        key_params = extract_key_params(key)
 
         params = params.transform_keys(&:to_sym)
         check_jwk(key_params, params)
@@ -72,6 +63,19 @@ module JWT
       end
 
       private
+
+      def extract_key_params(key)
+        case key
+        when JWT::JWK::HMAC
+          key.export(include_private: true)
+        when String # Accept String key as input
+          { kty: KTY, k: key }
+        when Hash
+          key.transform_keys(&:to_sym)
+        else
+          raise ArgumentError, 'key must be of type String or Hash with key parameters'
+        end
+      end
 
       def check_jwk(keypair, params)
         raise ArgumentError, 'cannot overwrite cryptographic key attributes' unless (HMAC_KEY_ELEMENTS & params.keys).empty?

--- a/lib/jwt/jwk/hmac.rb
+++ b/lib/jwt/jwk/hmac.rb
@@ -4,7 +4,7 @@ module JWT
   module JWK
     class HMAC < KeyBase
       KTY  = 'oct'
-      KTYS = [KTY, String].freeze
+      KTYS = [KTY, String, JWT::JWK::HMAC].freeze
       HMAC_PUBLIC_KEY_ELEMENTS = %i[kty].freeze
       HMAC_PRIVATE_KEY_ELEMENTS = %i[k].freeze
       HMAC_KEY_ELEMENTS = (HMAC_PRIVATE_KEY_ELEMENTS + HMAC_PUBLIC_KEY_ELEMENTS).freeze

--- a/lib/jwt/jwk/key_base.rb
+++ b/lib/jwt/jwk/key_base.rb
@@ -37,6 +37,8 @@ module JWT
         self[:kid] == other[:kid]
       end
 
+      alias eql? ==
+
       def <=>(other)
         self[:kid] <=> other[:kid]
       end

--- a/lib/jwt/jwk/key_base.rb
+++ b/lib/jwt/jwk/key_base.rb
@@ -25,6 +25,10 @@ module JWT
         self[:kid]
       end
 
+      def hash
+        self[:kid].hash
+      end
+
       def [](key)
         @parameters[key.to_sym]
       end

--- a/lib/jwt/jwk/key_base.rb
+++ b/lib/jwt/jwk/key_base.rb
@@ -33,6 +33,14 @@ module JWT
         @parameters[key.to_sym] = value
       end
 
+      def ==(other)
+        self[:kid] == other[:kid]
+      end
+
+      def <=>(other)
+        self[:kid] <=> other[:kid]
+      end
+
       private
 
       attr_reader :parameters

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -5,7 +5,7 @@ module JWT
     class RSA < KeyBase
       BINARY = 2
       KTY    = 'RSA'
-      KTYS   = [KTY, OpenSSL::PKey::RSA].freeze
+      KTYS   = [KTY, OpenSSL::PKey::RSA, JWT::JWK::RSA].freeze
       RSA_PUBLIC_KEY_ELEMENTS  = %i[kty n e].freeze
       RSA_PRIVATE_KEY_ELEMENTS = %i[d p q dp dq qi].freeze
       RSA_KEY_ELEMENTS = (RSA_PRIVATE_KEY_ELEMENTS + RSA_PUBLIC_KEY_ELEMENTS).freeze

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -2,7 +2,7 @@
 
 module JWT
   module JWK
-    class RSA < KeyBase
+    class RSA < KeyBase # rubocop:disable Metrics/ClassLength
       BINARY = 2
       KTY    = 'RSA'
       KTYS   = [KTY, OpenSSL::PKey::RSA, JWT::JWK::RSA].freeze
@@ -16,17 +16,7 @@ module JWT
         # For backwards compatibility when kid was a String
         params = { kid: params } if params.is_a?(String)
 
-        key_params = case key
-                     when JWT::JWK::RSA
-                       key.export(include_private: true)
-                     when OpenSSL::PKey::RSA # Accept OpenSSL key as input
-                       @keypair = key # Preserve the object to avoid recreation
-                       parse_rsa_key(key)
-                     when Hash
-                       key.transform_keys(&:to_sym)
-                     else
-                       raise ArgumentError, 'key must be of type OpenSSL::PKey::RSA or Hash with key parameters'
-        end
+        key_params = extract_key_params(key)
 
         params = params.transform_keys(&:to_sym)
         check_jwk(key_params, params)
@@ -71,6 +61,20 @@ module JWT
       end
 
       private
+
+      def extract_key_params(key)
+        case key
+        when JWT::JWK::RSA
+          key.export(include_private: true)
+        when OpenSSL::PKey::RSA # Accept OpenSSL key as input
+          @keypair = key # Preserve the object to avoid recreation
+          parse_rsa_key(key)
+        when Hash
+          key.transform_keys(&:to_sym)
+        else
+          raise ArgumentError, 'key must be of type OpenSSL::PKey::RSA or Hash with key parameters'
+        end
+      end
 
       def check_jwk(keypair, params)
         raise ArgumentError, 'cannot overwrite cryptographic key attributes' unless (RSA_KEY_ELEMENTS & params.keys).empty?

--- a/lib/jwt/jwk/rsa.rb
+++ b/lib/jwt/jwk/rsa.rb
@@ -17,6 +17,8 @@ module JWT
         params = { kid: params } if params.is_a?(String)
 
         key_params = case key
+                     when JWT::JWK::RSA
+                       key.export(include_private: true)
                      when OpenSSL::PKey::RSA # Accept OpenSSL key as input
                        @keypair = key # Preserve the object to avoid recreation
                        parse_rsa_key(key)

--- a/lib/jwt/jwk/set.rb
+++ b/lib/jwt/jwk/set.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module JWT
+  module JWK
+    class Set
+      include Enumerable
+
+      attr_reader :keys
+
+      def initialize(jwks)
+        jwks ||= {}
+
+        @keys = case jwks
+                when JWT::JWK::Set # Simple duplication
+                  jwks.keys
+                when JWT::JWK::KeyBase # Singleton
+                  [jwks]
+                when Hash
+                  jwks = jwks.transform_keys(&:to_sym)
+                  [*jwks[:keys]].map { |k| JWT::JWK.new k }
+                when Array
+                  jwks.map { |k| JWT::JWK.new k }
+                else
+                  raise ArgumentError, 'Can only create new JWKS from Hash, Array and JWK'
+        end
+      end
+
+      def export(options = {})
+        { keys: @keys.map { |k| k.export(options) } }
+      end
+
+      def each(&block)
+        @keys.each(&block)
+      end
+
+      def select!(&block)
+        return @keys.select! unless block
+
+        self if @keys.select!(&block)
+      end
+
+      def reject!(&block)
+        return @keys.reject! unless block
+
+        self if @keys.reject!(&block)
+      end
+
+      alias filter! select!
+
+      def size
+        @keys.size
+      end
+
+      alias length size
+
+      def merge(enum)
+        @keys += JWT::JWK::Set.new(enum.collect)
+        self
+      end
+
+      def union(enum)
+        dup.merge(enum)
+      end
+
+      def add(key)
+        @keys << JWT::JWK.new(key)
+        self
+      end
+
+      def ==(other)
+        other.is_a?(JWT::JWK::Set) && keys.sort == other.keys.sort
+      end
+
+      # For symbolic manipulation
+      alias | union
+      alias + union
+      alias << add
+    end
+  end
+end

--- a/lib/jwt/jwk/set.rb
+++ b/lib/jwt/jwk/set.rb
@@ -10,7 +10,7 @@ module JWT
 
       attr_reader :keys
 
-      def initialize(jwks = nil, options = {})
+      def initialize(jwks = nil, options = {}) # rubocop:disable Metrics/CyclomaticComplexity
         jwks ||= {}
 
         @keys = case jwks

--- a/spec/integration/readme_examples_spec.rb
+++ b/spec/integration/readme_examples_spec.rb
@@ -278,17 +278,17 @@ RSpec.describe 'README.md code test' do
         # ---------- ENCODE ----------
         optional_parameters = { kid: 'my-kid', use: 'sig', alg: 'RS512' }
         jwk = JWT::JWK.new(OpenSSL::PKey::RSA.new(2048), optional_parameters)
-        
+
         # Encoding
         payload = { data: 'data' }
         token = JWT.encode(payload, jwk.keypair, jwk[:alg], kid: jwk[:kid])
-        
+
         # JSON Web Key Set for advertising your signing keys
         jwks_hash = JWT::JWK::Set.new(jwk).export
 
         # ---------- DECODE ----------
         jwks = JWT::JWK::Set.new(jwks_hash)
-        jwks.filter! {|key| key[:use] == 'sig' } # Signing keys only!
+        jwks.filter! { |key| key[:use] == 'sig' } # Signing keys only!
         algorithms = jwks.map { |key| key[:alg] }.compact.uniq
         JWT.decode(token, nil, true, algorithms: algorithms, jwks: jwks)
       end
@@ -369,7 +369,7 @@ RSpec.describe 'README.md code test' do
             jwks
           end
         end
-        
+
         begin
           JWT.decode(token, nil, true, { algorithms: ['RS512'], jwks: jwks_loader })
         rescue JWT::JWKError

--- a/spec/jwk/decode_with_jwk_spec.rb
+++ b/spec/jwk/decode_with_jwk_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe JWT do
   describe '.decode for JWK usecase' do
     let(:keypair)       { OpenSSL::PKey::RSA.new(2048) }
     let(:jwk)           { JWT::JWK.new(keypair) }
-    let(:public_jwks) { { keys: [jwk.export, { kid: 'not_the_correct_one' }] } }
+    let(:public_jwks) { { keys: [jwk.export, { kid: 'not_the_correct_one', kty: 'oct', k: 'secret' }] } }
     let(:token_payload) { { 'data' => 'something' } }
     let(:token_headers) { { kid: jwk.kid } }
     let(:signed_token)  { described_class.encode(token_payload, jwk.keypair, 'RS512', token_headers) }

--- a/spec/jwk/set_spec.rb
+++ b/spec/jwk/set_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+RSpec.describe JWT::JWK::Set do
+  describe '.new' do
+    it 'can create an empty set' do
+      expect(described_class.new.keys).to eql([])
+    end
+
+    context 'can create a set' do
+      it 'from a JWK' do
+        jwk = JWT::JWK.new 'testkey'
+        expect(described_class.new(jwk).keys).to eql([jwk])
+      end
+
+      it 'from a JWKS hash with symbol keys' do
+        jwks = { keys: [{ kty: 'oct', k: 'testkey' }] }
+        jwk = JWT::JWK.new({ kty: 'oct', k: 'testkey' })
+        expect(described_class.new(jwks).keys).to eql([jwk])
+      end
+
+      it 'from a JWKS hash with string keys' do
+        jwks = { 'keys' => [{ 'kty' => 'oct', 'k' => 'testkey' }] }
+        jwk = JWT::JWK.new({ kty: 'oct', k: 'testkey' })
+        expect(described_class.new(jwks).keys).to eql([jwk])
+      end
+
+      it 'from an array of keys' do
+        jwk = JWT::JWK.new 'testkey'
+        expect(described_class.new([jwk]).keys).to eql([jwk])
+      end
+
+      it 'from an existing JWT::JWK::Set' do
+        jwk = JWT::JWK.new({ kty: 'oct', k: 'testkey' })
+        jwks = described_class.new(jwk)
+        expect(described_class.new(jwks)).to eql(jwks)
+      end
+    end
+
+    it 'raises an error on invalid inputs' do
+      expect { described_class.new(42) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '.export' do
+    it 'exports the JWKS to Hash' do
+      jwk = JWT::JWK.new({ kty: 'oct', k: 'testkey' })
+      jwks = described_class.new(jwk)
+      exported = jwks.export
+      expect(exported[:keys].size).to eql(1)
+      expect(exported[:keys][0]).to eql(jwk.export)
+    end
+  end
+
+  describe '.eql?' do
+    it 'correctly classifies equal sets' do
+      jwk = JWT::JWK.new({ kty: 'oct', k: 'testkey' })
+      jwks1 = described_class.new(jwk)
+      jwks2 = described_class.new(jwk)
+      expect(jwks1).to eql(jwks2)
+    end
+
+    it 'correctly classifies different sets' do
+      jwk1 = JWT::JWK.new({ kty: 'oct', k: 'testkey' })
+      jwk2 = JWT::JWK.new({ kty: 'oct', k: 'testkex' })
+      jwks1 = described_class.new(jwk1)
+      jwks2 = described_class.new(jwk2)
+      expect(jwks1).not_to eql(jwks2)
+    end
+  end
+
+  # TODO: No idea why this does not work. eql? returns true for the two elements,
+  #       but Array#uniq! doesn't recognize this, despite the documentation saying otherwise
+  describe '.uniq!' do
+    it 'filters out equal keys' do
+      jwk = JWT::JWK.new({ kty: 'oct', k: 'testkey' })
+      jwk2 = JWT::JWK.new({ kty: 'oct', k: 'testkey' })
+      jwks = described_class.new([jwk, jwk2])
+      jwks.uniq!
+      expect(jwks.keys.size).to eql(1)
+    end
+  end
+
+  describe '.select!' do
+    it 'filters the keyset' do
+      jwks = described_class.new([])
+      jwks << JWT::JWK.new(OpenSSL::PKey::RSA.new(2048))
+      jwks << JWT::JWK.new(OpenSSL::PKey::EC.generate('secp384r1'))
+      jwks.select! { |k| k[:kty] == 'RSA' }
+      expect(jwks.size).to eql(1)
+      expect(jwks.keys[0][:kty]).to eql('RSA')
+    end
+  end
+
+  describe '.reject!' do
+    it 'filters the keyset' do
+      jwks = described_class.new([])
+      jwks << JWT::JWK.new(OpenSSL::PKey::RSA.new(2048))
+      jwks << JWT::JWK.new(OpenSSL::PKey::EC.generate('secp384r1'))
+      jwks.reject! { |k| k[:kty] == 'RSA' }
+      expect(jwks.size).to eql(1)
+      expect(jwks.keys[0][:kty]).to eql('EC')
+    end
+  end
+
+  describe '.merge' do
+    context 'merges two JWKSs' do
+      it 'when called via .union' do
+        jwks1 = described_class.new(JWT::JWK.new(OpenSSL::PKey::RSA.new(2048)))
+        jwks2 = described_class.new(JWT::JWK.new(OpenSSL::PKey::EC.generate('secp384r1')))
+        jwks3 = jwks1.union(jwks2)
+        expect(jwks1.size).to eql(1)
+        expect(jwks2.size).to eql(1)
+        expect(jwks3.size).to eql(2)
+        expect(jwks3.keys).to include(jwks1.keys[0])
+        expect(jwks3.keys).to include(jwks2.keys[0])
+      end
+
+      it 'when called via "|" operator' do
+        jwks1 = described_class.new(JWT::JWK.new(OpenSSL::PKey::RSA.new(2048)))
+        jwks2 = described_class.new(JWT::JWK.new(OpenSSL::PKey::EC.generate('secp384r1')))
+        jwks3 = jwks1 | jwks2
+        expect(jwks1.size).to eql(1)
+        expect(jwks2.size).to eql(1)
+        expect(jwks3.size).to eql(2)
+        expect(jwks3.keys).to include(jwks1.keys[0])
+        expect(jwks3.keys).to include(jwks2.keys[0])
+      end
+
+      it 'when called directly' do
+        jwks1 = described_class.new(JWT::JWK.new(OpenSSL::PKey::RSA.new(2048)))
+        jwks2 = described_class.new(JWT::JWK.new(OpenSSL::PKey::EC.generate('secp384r1')))
+        jwks3 = jwks1.merge(jwks2)
+        expect(jwks1.size).to eql(2)
+        expect(jwks2.size).to eql(1)
+        expect(jwks3).to eql(jwks1)
+        expect(jwks3.keys).to include(jwks2.keys[0])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR Draft implements JWK Sets (Part of [RFC 7517](https://www.rfc-editor.org/rfc/rfc7517.html)) for easier handling of sets.

The goal was to make the handling of JWKS easier. E.g.

```ruby
json = Net::HTTP.get(my_friends_jwks_uri)
jwks = JWT::JWK::Set.new(JSON.parse(json))
jwks.filter! { |key| key[:use] == 'sig' } # Signing Keys only
algorithms = jwks.map { |key| key[:alg] } # & algs_allowed_by_local_policy
JWT.decode some_token, nil, true, algorithms: algorithms, jwks: jwks

my_jwks = JWT::JWK::Set.new # Empty JWKS
my_jwks << JWT::JWK.new(OpenSSL::PKey::RSA.new(2048), use: 'sig')
my_jwks << OpenSSL::PKey::RSA.new(2048)
my_jwks.merge(jwks)
hash = my_jwks.export
```

The draft allows for basic manipulation of the set:

- adding JWKs
- merging JWKSs
- filtering JWKs inside a JWKS
- `export`ing to Hash

Where possible, I tried to use function names and semantics common in the standard library, to not subvert user expectations.

There are currently no tests or documentation, but I would like to get some early feedback to incorporate :)
The selection of methods on JWKSs is currently based on stuff I find helpful in my projects, so feel free to request any changes.