### PR TITLE
Support combination of openssl GEM 3.0.1 with OpenSSL 3.0 on CI run

### DIFF
--- a/lib/jwt/version.rb
+++ b/lib/jwt/version.rb
@@ -25,4 +25,8 @@ module JWT
     return false if OpenSSL::OPENSSL_VERSION.include?('LibreSSL')
     return true if OpenSSL::OPENSSL_VERSION_NUMBER >= 3 * 0x10000000
   end
+
+  def self.openssl_3_hmac_empty_key_regression?
+    openssl_3? && ::Gem::Version.new(OpenSSL::VERSION) <= ::Gem::Version.new('3.0.0')
+  end
 end

--- a/spec/integration/readme_examples_spec.rb
+++ b/spec/integration/readme_examples_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'README.md code test' do
     end
 
     it 'decodes with HMAC algorithm without secret key' do
-      pending 'Different behaviour on OpenSSL 3.0 (https://github.com/openssl/openssl/issues/13089)' if ::JWT.openssl_3?
+      pending 'Different behaviour on OpenSSL 3.0 (https://github.com/openssl/openssl/issues/13089)' if ::JWT.openssl_3_hmac_empty_key_regression?
       token = JWT.encode payload, nil, 'HS256'
       decoded_token = JWT.decode token, nil, false
 

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -629,7 +629,7 @@ RSpec.describe JWT do
 
   context 'when hmac algorithm is used without secret key' do
     it 'encodes payload' do
-      pending 'Different behaviour on OpenSSL 3.0 (https://github.com/openssl/openssl/issues/13089)' if ::JWT.openssl_3?
+      pending 'Different behaviour on OpenSSL 3.0 (https://github.com/openssl/openssl/issues/13089)' if ::JWT.openssl_3_hmac_empty_key_regression?
       payload = { a: 1, b: 'b' }
 
       token = JWT.encode(payload, '', 'HS256')
@@ -760,7 +760,7 @@ RSpec.describe JWT do
   describe 'when token signed with nil and decoded with nil' do
     let(:no_key_token) { ::JWT.encode(payload, nil, 'HS512') }
     it 'raises JWT::DecodeError' do
-      pending 'Different behaviour on OpenSSL 3.0 (https://github.com/openssl/openssl/issues/13089)' if ::JWT.openssl_3?
+      pending 'Different behaviour on OpenSSL 3.0 (https://github.com/openssl/openssl/issues/13089)' if ::JWT.openssl_3_hmac_empty_key_regression?
       expect { ::JWT.decode(no_key_token, nil, true, algorithms: 'HS512') }.to raise_error(JWT::DecodeError, 'No verification key available')
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,10 @@ end
 
 require 'jwt'
 
+puts "OpenSSL::VERSION: #{OpenSSL::VERSION}"
+puts "OpenSSL::OPENSSL_VERSION: #{OpenSSL::OPENSSL_VERSION}"
+puts "OpenSSL::OPENSSL_LIBRARY_VERSION: #{OpenSSL::OPENSSL_LIBRARY_VERSION}\n\n"
+
 CERT_PATH = File.join(File.dirname(__FILE__), 'fixtures', 'certs')
 
 RSpec.configure do |config|


### PR DESCRIPTION
This PR fixes the test suite to expect the hmac empty key regression to be fixed in openssl 3.0.1

Also OpenSSL versions printed out on CI run for easier debugging.
