### PR TITLE
Bugfix - Raise Descriptive Error for hmac_secret empty and OpenSSL 3.0 Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ puts decoded_token
 * HS512 - HMAC using SHA-512 hash algorithm
 
 ```ruby
-# The secret must be a string. A JWT::DecodeError will be raised if it isn't provided.
+# The secret must be a string. With OpenSSL 3.0, JWT::DecodeError will be raised if it isn't provided.
 hmac_secret = 'my$ecretK3y'
 
 token = JWT.encode payload, hmac_secret, 'HS256'

--- a/spec/jwt/algos/ecdsa_spec.rb
+++ b/spec/jwt/algos/ecdsa_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe ::JWT::Algos::Ecdsa do
       it { is_expected.to eq(algorithm: 'ES256K', digest: 'sha256') }
     end
 
-    context 'when unkown is given' do
-      let(:curve_name) { 'unkown' }
+    context 'when unknown is given' do
+      let(:curve_name) { 'unknown' }
       it 'raises an error' do
         expect { subject }.to raise_error(JWT::UnsupportedEcdsaCurve)
       end

--- a/spec/jwt/algos/hmac_spec.rb
+++ b/spec/jwt/algos/hmac_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+RSpec.describe ::JWT::Algos::Hmac do
+  describe '.sign' do
+    subject { described_class.sign('HS256', 'test', hmac_secret) }
+
+    # Address OpenSSL 3.0 errors with empty hmac_secret - https://github.com/jwt/ruby-jwt/issues/526
+    context 'when nil hmac_secret is passed' do
+      let(:hmac_secret) { nil }
+      context 'when OpenSSL 3.0 raises a malloc failure' do
+        before do
+          allow(OpenSSL::HMAC).to receive(:digest).and_raise(OpenSSL::HMACError.new('EVP_PKEY_new_mac_key: malloc failure'))
+        end
+
+        it 'raises JWT::DecodeError' do
+          expect { subject }.to raise_error(JWT::DecodeError, 'OpenSSL 3.0 does not support nil or empty hmac_secret')
+        end
+      end
+
+      context 'when OpenSSL raises any other error' do
+        before do
+          allow(OpenSSL::HMAC).to receive(:digest).and_raise(OpenSSL::HMACError.new('Another Random Error'))
+        end
+
+        it 'raises the original error' do
+          expect { subject }.to raise_error(OpenSSL::HMACError, 'Another Random Error')
+        end
+      end
+
+      context 'when other versions of openssl do not raise an exception' do
+        let(:response) { Base64.decode64("Q7DO+ZJl+eNMEOqdNQGSbSezn1fG1nRWHYuiNueoGfs=\n") }
+        before do
+          allow(OpenSSL::HMAC).to receive(:digest).and_return(response)
+        end
+
+        it { is_expected.to eql(response) }
+      end
+    end
+
+    context 'when blank hmac_secret is passed' do
+      let(:hmac_secret) { '' }
+      context 'when OpenSSL 3.0 raises a malloc failure' do
+        before do
+          allow(OpenSSL::HMAC).to receive(:digest).and_raise(OpenSSL::HMACError.new('EVP_PKEY_new_mac_key: malloc failure'))
+        end
+
+        it 'raises JWT::DecodeError' do
+          expect { subject }.to raise_error(JWT::DecodeError, 'OpenSSL 3.0 does not support nil or empty hmac_secret')
+        end
+      end
+
+      context 'when OpenSSL raises any other error' do
+        before do
+          allow(OpenSSL::HMAC).to receive(:digest).and_raise(OpenSSL::HMACError.new('Another Random Error'))
+        end
+
+        it 'raises the original error' do
+          expect { subject }.to raise_error(OpenSSL::HMACError, 'Another Random Error')
+        end
+      end
+
+      context 'when other versions of openssl do not raise an exception' do
+        let(:response) { Base64.decode64("Q7DO+ZJl+eNMEOqdNQGSbSezn1fG1nRWHYuiNueoGfs=\n") }
+        before do
+          allow(OpenSSL::HMAC).to receive(:digest).and_return(response)
+        end
+
+        it { is_expected.to eql(response) }
+      end
+    end
+
+    context 'when hmac_secret is passed' do
+      let(:hmac_secret) { 'test' }
+      context 'when OpenSSL 3.0 raises a malloc failure' do
+        before do
+          allow(OpenSSL::HMAC).to receive(:digest).and_raise(OpenSSL::HMACError.new('EVP_PKEY_new_mac_key: malloc failure'))
+        end
+
+        it 'raises the original error' do
+          expect { subject }.to raise_error(OpenSSL::HMACError, 'EVP_PKEY_new_mac_key: malloc failure')
+        end
+      end
+
+      context 'when OpenSSL raises any other error' do
+        before do
+          allow(OpenSSL::HMAC).to receive(:digest).and_raise(OpenSSL::HMACError.new('Another Random Error'))
+        end
+
+        it 'raises the original error' do
+          expect { subject }.to raise_error(OpenSSL::HMACError, 'Another Random Error')
+        end
+      end
+
+      context 'when other versions of openssl do not raise an exception' do
+        let(:response) { Base64.decode64("iM0hCLU0fZc885zfkFPX3UJwSHbYyam9ji0WglnT3fc=\n") }
+        before do
+          allow(OpenSSL::HMAC).to receive(:digest).and_return(response)
+        end
+
+        it { is_expected.to eql(response) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/jwt/ruby-jwt/issues/526.


Changes error when utilizing empty `hmac_secret` from cryptic:
```
irb(main):017:0> JWT::Algos::Hmac.sign('HS256','test','')
...
OpenSSL::HMACError (EVP_PKEY_new_mac_key: malloc failure)
```

to clearer error:

```
irb(main):017:0> JWT::Algos::Hmac.sign('HS256','test','')
...
JWT::DecodeError (OpenSSL 3.0 does not support nil or empty hmac_secret)
```