### PR TITLE
Tests for missing and empty token header

### DIFF
--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -781,6 +781,21 @@ RSpec.describe JWT do
     end
   end
 
+  context 'when token is missing the alg header' do
+    let(:token) { 'e30.eyJ1c2VyX2lkIjoic29tZUB1c2VyLnRsZCJ9.DIKUOt1lwwzWSPBf508IYqk0KzC2PL97OZc6pECzE1I' }
+
+    it 'raises JWT::IncorrectAlgorithm error' do
+      expect { JWT.decode(token, 'secret', true, algorithm: 'HS256') }.to raise_error(JWT::IncorrectAlgorithm, 'Token is missing alg header')
+    end
+  end
+
+  context 'when token has null as the alg header' do
+    let(:token) { 'eyJhbGciOm51bGx9.eyJwYXkiOiJsb2FkIn0.pizVPWJMK-GUuXXEcQD_faZGnZqz_6wKZpoGO4RdqbY' }
+    it 'raises JWT::IncorrectAlgorithm error' do
+      expect { JWT.decode(token, 'secret', true, algorithm: 'HS256') }.to raise_error(JWT::IncorrectAlgorithm, 'Token is missing alg header')
+    end
+  end
+
   context 'when algorithm is a custom class' do
     let(:custom_algorithm) do
       Class.new do


### PR DESCRIPTION
While looking into #534 i noticed that there are no tests to verify the behaviour when there is no `alg` header.

This PR adds a few tests to ensure the behaviour for the alg header on decode.