### PR TITLE
`allow_nil_kid` option for the JWK KeyFinder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@
 **Features:**
 
 - Your contribution here
+- JWK Sets can now be used for tokens with nil kid[#543](https://github.com/jwt/ruby-jwt/pull/543) ([@bellebaum](https://github.com/bellebaum))
 
 **Fixes and enhancements:**
 
 - Your contribution here
+- Non-string `kid` header values are now rejected[#543](https://github.com/jwt/ruby-jwt/pull/543) ([@bellebaum](https://github.com/bellebaum))
 
 ## [v2.6.0](https://github.com/jwt/ruby-jwt/tree/v2.6.0) (2022-12-22)
 

--- a/README.md
+++ b/README.md
@@ -601,6 +601,9 @@ This can be used to implement caching of remotely fetched JWK Sets.
 If the requested `kid` is not found from the given set the loader will be called a second time with the `kid_not_found` option set to `true`.
 The application can choose to implement some kind of JWK cache invalidation or other mechanism to handle such cases.
 
+Tokens without a specified `kid` are rejected by default.
+This behaviour may be overwritten by setting the `allow_nil_jwks` option for `decode` to `true`.
+
 ```ruby
 jwks_loader = ->(options) do
   # The jwk loader would fetch the set of JWKs from a trusted source.

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -57,7 +57,7 @@ module JWT
 
     def set_key
       @key = find_key(&@keyfinder) if @keyfinder
-      @key = ::JWT::JWK::KeyFinder.new(jwks: @options[:jwks]).key_for(header['kid']) if @options[:jwks]
+      @key = ::JWT::JWK::KeyFinder.new(jwks: @options[:jwks], allow_nil_kid: @options[:allow_nil_kid]).key_for(header['kid']) if @options[:jwks]
       if (x5c_options = @options[:x5c])
         @key = X5cKeyFinder.new(x5c_options[:root_certificates], x5c_options[:crls]).from(header['x5c'])
       end

--- a/lib/jwt/jwk/key_finder.rb
+++ b/lib/jwt/jwk/key_finder.rb
@@ -16,6 +16,7 @@ module JWT
 
       def key_for(kid)
         raise ::JWT::DecodeError, 'No key id (kid) found from token headers' unless kid || @allow_nil_kid
+        raise ::JWT::DecodeError, 'Invalid type for kid header parameter' unless kid.nil? || kid.is_a?(String)
 
         jwk = resolve_key(kid)
 

--- a/spec/jwk/decode_with_jwk_spec.rb
+++ b/spec/jwk/decode_with_jwk_spec.rb
@@ -90,6 +90,15 @@ RSpec.describe JWT do
       end
     end
 
+    context 'when the token kid is not a string' do
+      let(:token_headers) { { kid: 5 } }
+      it 'raises an exception' do
+        expect { described_class.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: public_jwks }) }.to raise_error(
+          JWT::DecodeError, 'Invalid type for kid header parameter'
+        )
+      end
+    end
+
     context 'mixing algorithms using kid header' do
       let(:hmac_jwk)           { JWT::JWK.new('secret') }
       let(:rsa_jwk)            { JWT::JWK.new(OpenSSL::PKey::RSA.new(2048)) }

--- a/spec/jwk/decode_with_jwk_spec.rb
+++ b/spec/jwk/decode_with_jwk_spec.rb
@@ -79,6 +79,17 @@ RSpec.describe JWT do
       end
     end
 
+    context 'when the token kid is nil' do
+      let(:token_headers) { {} }
+      context 'and allow_nil_kid is specified' do
+        it 'decodes the token' do
+          key_loader = ->(_options) { JSON.parse(JSON.generate(public_jwks)) }
+          payload, _header = described_class.decode(signed_token, nil, true, { algorithms: ['RS512'], jwks: key_loader, allow_nil_kid: true })
+          expect(payload).to eq(token_payload)
+        end
+      end
+    end
+
     context 'mixing algorithms using kid header' do
       let(:hmac_jwk)           { JWT::JWK.new('secret') }
       let(:rsa_jwk)            { JWT::JWK.new(OpenSSL::PKey::RSA.new(2048)) }


### PR DESCRIPTION
When a JWT does not specify a `kid` explicitly in its header, its key may still have to be fetched from a JWKS.
This may happen e.g. when there is only one key in the JWKS and thus there is no need to specify an ID.

This PR adds a decoding option `:allow_nil_kid`, which, when used in conjunction with the `:jwks` option, prevents an error from being raised when the JWT does not specify the `kid`.
In this case, the first key in the provided JWKS is used as the decryption key.

To prevent application jwks-handlers from being overwhelmed by a sudden nil in the options hash, the functionality is disabled by default. (To be fair though, there are no type checks on `kid` and this is all before any verification has happened, so applications _should_ have implemented the necessary checks anyways. So there is an argument that one could just make this the default. :D)
