### PR TITLE
Automatic JWK enrichment

### DIFF
--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -16,6 +16,12 @@ module JWT
           end.new(key, params, options)
         end
 
+        # Certificate to JWK
+        if key.is_a?(OpenSSL::X509::Certificate)
+          x5c = [::Base64.strict_encode64(key.to_der)]
+          return create_from(key.public_key, { x5c: x5c }, enrich_key: true)
+        end
+
         mappings.fetch(key.class) do |klass|
           raise JWT::JWKError, "Cannot create JWK from a #{klass.name}"
         end.new(key, params, options)

--- a/lib/jwt/jwk/key_base.rb
+++ b/lib/jwt/jwk/key_base.rb
@@ -19,6 +19,8 @@ module JWT
         # Make sure the key has a kid
         kid_generator = options[:kid_generator] || ::JWT.configuration.jwk.kid_generator
         self[:kid] ||= kid_generator.new(self).generate
+
+        enrich_key(options) if options[:enrich_key]
       end
 
       def kid
@@ -50,6 +52,83 @@ module JWT
       private
 
       attr_reader :parameters
+
+      KEY_USAGES_SIG  = ['Digital Signature', 'Non Repudiation', 'Content Commitment', 'Key Cert Sign', 'CRL Sign'].freeze
+      KEY_USAGES_ENC  = ['Key Encipherment', 'Data Encipherment', 'Key Agreement'].freeze
+      KEY_OPS_VERIFY  = ['Digital Signature', 'Key Cert Sign', 'CRL Sign'].freeze
+      KEY_OPS_ENCRYPT = ['Data Encipherment'].freeze
+      KEY_OPS_WRAPKEY = ['Key Encipherment'].freeze
+
+      # Tries to derive additional key parameters from a certificate chain while maintaining semantic consistency
+      # Does not as of now validate the chain
+      def enrich_key(options)
+        certs = fetch_certificates(options)
+        if certs
+          add_thumbprints(certs.first)
+          add_key_operations(certs.first)
+          add_private_key_operations
+          add_usages(certs.first)
+        end
+        add_default_algorithm
+      end
+
+      # Try to find certificates. TODO: Suitably validate chain
+      def fetch_certificates(options)
+        certs = self[:x5c]&.map { |c| OpenSSL::X509::Certificate.new(::Base64.strict_decode64(c)) }
+        certs = options[:x5u_handler].call(self[:x5u]) if self[:x5u] && options[:x5u_handler]
+        certs if certs&.first
+      end
+
+      # Extract certificate key usages
+      def certificate_usages(certificate)
+        certificate.extensions&.find { |ext| ext.oid == 'keyUsage' }&.value&.split("\n")
+      end
+
+      # Set standard thumbprint parameters
+      def add_thumbprints(certificate)
+        self[:x5t]        ||= ::Base64.urlsafe_encode64(OpenSSL::Digest.new('SHA1',   certificate.to_der).to_s)
+        self[:'x5t#S256'] ||= ::Base64.urlsafe_encode64(OpenSSL::Digest.new('SHA256', certificate.to_der).to_s)
+      end
+
+      # Set standard use parameter
+      # C.t. RFC 5280, Section 4.2.1.3
+      # We do not care about encipherOnly and decipherOnly for the `use` param
+      def add_usages(certificate)
+        key_usages = certificate_usages(certificate)
+        self[:use] ||= 'sig' unless (KEY_USAGES_SIG & [*key_usages]).empty?
+        self[:use] ||= 'enc' unless (KEY_USAGES_ENC & [*key_usages]).empty?
+      end
+
+      # Tries to add a suitable key_ops parameter
+      def add_key_operations(certificate)
+        key_usages = certificate_usages(certificate)
+        self[:key_ops] ||= ['verify']  unless ([*key_usages] & KEY_OPS_VERIFY).empty? # sign
+        self[:key_ops] ||= ['encrypt'] unless ([*key_usages] & KEY_OPS_ENCRYPT).empty? # decrypt
+        self[:key_ops] ||= ['wrapKey'] unless ([*key_usages] & KEY_OPS_WRAPKEY).empty? # unwrapKey
+      end
+
+      # Adds the private counterpart to key operations for private keys
+      def add_private_key_operations
+        return unless private? && self[:key_ops]
+
+        self[:key_ops] << {
+          'verify' => 'sign',
+          'encrypt' => 'decrypt',
+          'wrapKey' => 'unwrapKey'
+        }[self[:key_ops].first]
+        self[:key_ops].uniq!
+      end
+
+      # Adds a default algorithm to each key, depending on the type.
+      def add_default_algorithm
+        return unless self[:use] == 'sig' # Only signing algorithms supported
+
+        self[:alg] = {
+          'RSA' => 'RS512',
+          'EC' => 'ES512',
+          'oct' => 'HS512'
+        }[self[:kty]]
+      end
     end
   end
 end

--- a/spec/jwk_spec.rb
+++ b/spec/jwk_spec.rb
@@ -82,6 +82,66 @@ RSpec.describe JWT::JWK do
         expect(subject[:use]).to eq('sig')
       end
     end
+
+    context 'when enrich_key is specified' do
+      subject { described_class.new(keypair, params, enrich_key: true) }
+      let(:keypair) { rsa_key }
+      let(:params) { { 'use' => 'sig' } }
+      it 'sets a suitable default alg header' do
+        expect(subject[:use]).not_to eq(nil)
+      end
+
+      context 'when given an X.509 certificate chain' do
+        let(:certificate_base) {
+          cert = OpenSSL::X509::Certificate.new
+          cert.version = 2
+          cert.serial = 1
+          cert.subject = OpenSSL::X509::Name.parse '/CN=Test'
+          cert.issuer = cert.subject # Self-signed
+          cert.public_key = keypair.public_key
+          cert.not_before = Time.now
+          cert.not_after = cert.not_before + 3600 # 1h
+          cert
+        }
+        let(:certificate_unsigned) { certificate_base }
+        let(:certificate) { certificate_unsigned.sign(keypair, OpenSSL::Digest.new('SHA256')) }
+        let(:x5c) { [::Base64.strict_encode64(certificate.to_der)] }
+
+        context 'in the x5c header' do
+          subject { described_class.new(keypair, { x5c: x5c }, enrich_key: true) }
+          it 'adds the thumbprints' do
+            expect(subject[:x5t]).not_to eq(nil)
+            expect(subject[:'x5t#S256']).not_to eq(nil)
+          end
+        end
+
+        context 'in the x5u header' do
+          let(:cert_fetcher) { ->(url) { x5c.map { |c| OpenSSL::X509::Certificate.new(::Base64.strict_decode64(c)) } if url == 'https://example.org/certs' } }
+          subject { described_class.new(keypair, { x5u: 'https://example.org/certs' }, enrich_key: true, x5u_handler: cert_fetcher) }
+          it 'adds the thumbprints' do
+            expect(subject[:x5t]).not_to eq(nil)
+            expect(subject[:'x5t#S256']).not_to eq(nil)
+          end
+        end
+
+        context 'with keyUsage extension' do
+          let(:certificate_unsigned) {
+            ef = OpenSSL::X509::ExtensionFactory.new
+            certificate_base.add_extension(ef.create_extension('keyUsage', 'digitalSignature', true))
+            certificate_base
+          }
+          subject { described_class.new(keypair, { x5c: x5c }, enrich_key: true) }
+          it 'derives the correct key operations and usages' do
+            expect(subject[:key_ops]).to eq(['verify', 'sign'])
+            expect(subject[:use]).to eq('sig')
+          end
+
+          it 'sets a suitable default alg header' do
+            expect(subject[:use]).not_to eq(nil)
+          end
+        end
+      end
+    end
   end
 
   describe '.[]' do


### PR DESCRIPTION
This PR will allow to derive most standardized common parameters from already specified parameters.
This is a follow-up to a few points which could not be addressed in #520, but were brought up by me in #518.

# Overview

Using all of its features, given an X.509 certificate, you can acquire a JWK like this:

```ruby
::JWT::JWK.new(certificate)
```

This will extract the public key, construct the JWK, and try to set the following parameters:

- `kid` as previously implemented
- `x5c` is a representation of the certificate
- `x5t` and `x5t#S256` are wide-spread certificate thumbprints
- `key_ops` and `use` state allowed key usages and are derived from the X.509 `keyUsage` extension, if present
- `alg` will be set to a sensible default depending on `use` and `kty`

Of course, any parameters specified in the above invocation will still take precedence.

There is even support for the `x5u` parameter, to fetch a remote certificate chain:

```ruby
x5u_fetcher = ->(uri) {
    # Fetch uri, return as Array of OpenSSL::X509::Certificate
}
::JWT::JWK.new(jwks_hash, nil, enrich_key: true, x5u_handler: x5u_fetcher)
```

# TODO

- [ ] Proper certificate validation
- [ ] Check if code from `x5c_key_finder` can be reused
- [ ] new README examples
- [ ] Update changelog
