### PR TITLE
Move rescue OpenSSL::PKey::PKeyError into algorithms

### DIFF
--- a/lib/jwt/algos/algo_wrapper.rb
+++ b/lib/jwt/algos/algo_wrapper.rb
@@ -20,10 +20,6 @@ module JWT
 
       def verify(data:, signature:, verification_key:)
         cls.verify(alg, verification_key, data, signature)
-      rescue OpenSSL::PKey::PKeyError # These should be moved to the algorithms that actually need this, but left here to ensure nothing will break.
-        raise JWT::VerificationError, 'Signature verification raised'
-      ensure
-        OpenSSL.errors.clear
       end
     end
   end

--- a/lib/jwt/algos/ecdsa.rb
+++ b/lib/jwt/algos/ecdsa.rb
@@ -50,6 +50,8 @@ module JWT
 
         digest = OpenSSL::Digest.new(curve_definition[:digest])
         public_key.dsa_verify_asn1(digest.digest(signing_input), raw_to_asn1(signature, public_key))
+      rescue OpenSSL::PKey::PKeyError
+        raise JWT::VerificationError, 'Signature verification raised'
       end
 
       def curve_by_name(name)

--- a/lib/jwt/algos/ps.rb
+++ b/lib/jwt/algos/ps.rb
@@ -23,6 +23,8 @@ module JWT
         require_openssl!
         translated_algorithm = algorithm.sub('PS', 'sha')
         public_key.verify_pss(translated_algorithm, signature, signing_input, salt_length: :auto, mgf1_hash: translated_algorithm)
+      rescue OpenSSL::PKey::PKeyError
+        raise JWT::VerificationError, 'Signature verification raised'
       end
 
       def require_openssl!

--- a/lib/jwt/algos/rsa.rb
+++ b/lib/jwt/algos/rsa.rb
@@ -15,6 +15,8 @@ module JWT
 
       def verify(algorithm, public_key, signing_input, signature)
         public_key.verify(OpenSSL::Digest.new(algorithm.sub('RS', 'sha')), signature, signing_input)
+      rescue OpenSSL::PKey::PKeyError
+        raise JWT::VerificationError, 'Signature verification raised'
       end
     end
   end


### PR DESCRIPTION
Moved the rescue of OpenSSL::PKey::PKeyError closer to the algorithms to be less a rescue "just in case".

Also removed the `OpenSSL.errors.clear` the documentation for the `OpenSSL.errors` states "Any errors you see here are probably due to a bug in Ruby's OpenSSL implementation"