### PR TITLE
fix signature has expired error if payload is a string

### DIFF
--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -38,12 +38,12 @@ module JWT
     end
 
     def verify_expiration
-      return unless @payload.has_key?('exp')
+      return unless @payload.key?('exp')
       raise(JWT::ExpiredSignature, 'Signature has expired') if @payload['exp'].to_i <= (Time.now.to_i - exp_leeway)
     end
 
     def verify_iat
-      return unless @payload.has_key?('iat')
+      return unless @payload.key?('iat')
 
       iat = @payload['iat']
       raise(JWT::InvalidIatError, 'Invalid iat') if !iat.is_a?(Numeric) || iat.to_f > Time.now.to_f
@@ -77,7 +77,7 @@ module JWT
     end
 
     def verify_not_before
-      return unless @payload.has_key?('nbf')
+      return unless @payload.key?('nbf')
       raise(JWT::ImmatureSignature, 'Signature nbf has not been reached') if @payload['nbf'].to_i > (Time.now.to_i + nbf_leeway)
     end
 
@@ -92,7 +92,7 @@ module JWT
       return unless (options_required_claims = @options[:required_claims])
 
       options_required_claims.each do |required_claim|
-        raise(JWT::MissingRequiredClaim, "Missing required claim #{required_claim}") unless @payload.has_key?(required_claim)
+        raise(JWT::MissingRequiredClaim, "Missing required claim #{required_claim}") unless @payload.key?(required_claim)
       end
     end
 

--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -38,12 +38,12 @@ module JWT
     end
 
     def verify_expiration
-      return unless @payload.include?('exp')
+      return unless @payload.has_key?('exp')
       raise(JWT::ExpiredSignature, 'Signature has expired') if @payload['exp'].to_i <= (Time.now.to_i - exp_leeway)
     end
 
     def verify_iat
-      return unless @payload.include?('iat')
+      return unless @payload.has_key?('iat')
 
       iat = @payload['iat']
       raise(JWT::InvalidIatError, 'Invalid iat') if !iat.is_a?(Numeric) || iat.to_f > Time.now.to_f
@@ -77,7 +77,7 @@ module JWT
     end
 
     def verify_not_before
-      return unless @payload.include?('nbf')
+      return unless @payload.has_key?('nbf')
       raise(JWT::ImmatureSignature, 'Signature nbf has not been reached') if @payload['nbf'].to_i > (Time.now.to_i + nbf_leeway)
     end
 
@@ -92,7 +92,7 @@ module JWT
       return unless (options_required_claims = @options[:required_claims])
 
       options_required_claims.each do |required_claim|
-        raise(JWT::MissingRequiredClaim, "Missing required claim #{required_claim}") unless @payload.include?(required_claim)
+        raise(JWT::MissingRequiredClaim, "Missing required claim #{required_claim}") unless @payload.has_key?(required_claim)
       end
     end
 

--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -38,12 +38,12 @@ module JWT
     end
 
     def verify_expiration
-      return unless @payload.key?('exp')
+      return unless contains_key?(@payload, 'exp')
       raise(JWT::ExpiredSignature, 'Signature has expired') if @payload['exp'].to_i <= (Time.now.to_i - exp_leeway)
     end
 
     def verify_iat
-      return unless @payload.key?('iat')
+      return unless contains_key?(@payload, 'iat')
 
       iat = @payload['iat']
       raise(JWT::InvalidIatError, 'Invalid iat') if !iat.is_a?(Numeric) || iat.to_f > Time.now.to_f
@@ -77,7 +77,7 @@ module JWT
     end
 
     def verify_not_before
-      return unless @payload.key?('nbf')
+      return unless contains_key?(@payload, 'nbf')
       raise(JWT::ImmatureSignature, 'Signature nbf has not been reached') if @payload['nbf'].to_i > (Time.now.to_i + nbf_leeway)
     end
 
@@ -92,7 +92,7 @@ module JWT
       return unless (options_required_claims = @options[:required_claims])
 
       options_required_claims.each do |required_claim|
-        raise(JWT::MissingRequiredClaim, "Missing required claim #{required_claim}") unless @payload.key?(required_claim)
+        raise(JWT::MissingRequiredClaim, "Missing required claim #{required_claim}") unless contains_key?(@payload, required_claim)
       end
     end
 
@@ -108,6 +108,10 @@ module JWT
 
     def nbf_leeway
       @options[:nbf_leeway] || global_leeway
+    end
+
+    def contains_key?(payload, key)
+      payload.respond_to?(:key?) && payload.key?(key)
     end
   end
 end

--- a/spec/jwt/verify_spec.rb
+++ b/spec/jwt/verify_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe ::JWT::Verify do
   let(:base_payload) { { 'user_id' => 'some@user.tld' } }
+  let(:string_payload) { 'beautyexperts_nbf_iat' }
   let(:options) { { leeway: 0 } }
 
   context '.verify_aud(payload, options)' do
@@ -64,6 +65,10 @@ RSpec.describe ::JWT::Verify do
       end.to raise_error JWT::ExpiredSignature
     end
 
+    it 'must not consider string containing exp as expired' do
+      expect(described_class.verify_expiration(string_payload, options)).to eq(nil)
+    end
+
     context 'when leeway is not specified' do
       let(:options) { {} }
 
@@ -102,6 +107,10 @@ RSpec.describe ::JWT::Verify do
       expect do
         described_class.verify_iat(payload.merge('iat' => (iat + 120)), options)
       end.to raise_error JWT::InvalidIatError
+    end
+
+    it 'must not validate if the payload is a string containing iat' do
+      expect(described_class.verify_iat(string_payload, options)).to eq(nil)
     end
   end
 
@@ -264,6 +273,10 @@ RSpec.describe ::JWT::Verify do
 
     it 'must allow some leeway in the token age when nbf_leeway is configured' do
       described_class.verify_not_before(payload, options.merge(nbf_leeway: 10))
+    end
+
+    it 'must not validate if the payload is a string containing iat' do
+      expect(described_class.verify_not_before(string_payload, options)).to eq(nil)
     end
   end
 


### PR DESCRIPTION
currently it's possible to encode a string payload and decode it but decoding a string containing "exp" throws signature has expired payload which could be misleading as the payload has to be a hash inorder for this to work properly.

Possible before this PR:
```ruby
payload = "Hello"
secret = "secret"
token = JWT.encode payload, secret
#"eyJhbGciOiJIUzI1NiJ9.IkhlbGxvIg.gR1jkofv3fsS7g6lgRR5pBEuePbpWTuUEQ847GKQ7mc"
JWT.decode token, secret
#["Hello", {"alg"=>"HS256"}]
```

```ruby
payload = "beautyexperts" #contains exp
secret = "secret"
token = JWT.encode payload, secret
#"eyJhbGciOiJIUzI1NiJ9.ImJlYXV0eWV4cGVydHMi.7zl7sGM_oNoo1nCUH22chd0Ofi67n9GEfN0DS1_lR7w"
JWT.decode token, secret
#.rbenv/versions/3.0.5/lib/ruby/gems/3.0.0/gems/jwt-2.7.0/lib/jwt/verify.rb:42:in `verify_expiration': Signature has expired (JWT::ExpiredSignature)
```

Reason for making this PR is has_key will atleast throw undefined method error so that the error won't go unnoticed in production if the payload is a string by mistake.