### PR TITLE
Fix test assertion for exception message content

### DIFF
--- a/spec/jwk/decode_with_jwk_spec.rb
+++ b/spec/jwk/decode_with_jwk_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe JWT do
 
         it 'fails in some way' do
           expect { described_class.decode(signed_token, nil, true, algorithms: [algorithm], jwks: jwks) }.to(
-            raise_error(NoMethodError, /undefined method `verify' for "secret":String/)
+            raise_error(NoMethodError, /undefined method `verify' for/)
           )
         end
       end
@@ -148,7 +148,7 @@ RSpec.describe JWT do
 
         it 'fails in some way' do
           expect { described_class.decode(signed_token, nil, true, algorithms: ['ES384'], jwks: jwks) }.to(
-            raise_error(NoMethodError, /undefined method `group' for "secret":String/)
+            raise_error(NoMethodError, /undefined method `group' for/)
           )
         end
       end


### PR DESCRIPTION
Exception messages changing in Ruby 3.3. This makes assertion in tests compatible.