### PR TITLE
Add support for RFC7797 unencoded payloads

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ Metrics/AbcSize:
   Max: 25
 
 Metrics/ClassLength:
-  Max: 121
+  Max: 135
 
 Metrics/ModuleLength:
   Max: 100

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ Metrics/AbcSize:
   Max: 25
 
 Metrics/ClassLength:
-  Max: 135
+  Max: 140
 
 Metrics/ModuleLength:
   Max: 100

--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -22,7 +22,16 @@ module JWT
     Encode.new(payload: payload,
                key: key,
                algorithm: algorithm,
-               headers: header_fields).segments
+               headers: header_fields,
+               detached: false).segments
+  end
+
+  def encode_detached(payload, key, algorithm = 'HS256', header_fields = {})
+    Encode.new(payload: payload,
+               key: key,
+               algorithm: algorithm,
+               headers: header_fields,
+               detached: true).segments
   end
 
   def decode(jwt, key = nil, verify = true, options = {}, &keyfinder) # rubocop:disable Style/OptionalBooleanParameter

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -157,8 +157,14 @@ module JWT
     end
 
     def encoded_payload
-      payload = @detached_payload.to_json if !@detached_payload.nil? && @segments[1].empty?
+      payload = encoded_detached_payload if !@detached_payload.nil? && @segments[1].empty?
       payload ||= @segments[1]
+      payload
+    end
+
+    def encoded_detached_payload
+      payload ||= ::JWT::Base64.url_encode(JWT::JSON.generate(@detached_payload)) if decode_payload?
+      payload ||= @detached_payload.to_json
       payload
     end
 

--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -15,11 +15,24 @@ module JWT
       @algorithm        = resolve_algorithm(options[:algorithm])
       @headers          = options[:headers].transform_keys(&:to_s)
       @headers[ALG_KEY] = @algorithm.alg
+      @detached         = options[:detached]
+
+      # add b64 claim to crit as per RFC7797 proposed standard
+      unless encode_payload?
+        @headers['crit'] ||= []
+        @headers['crit'] << 'b64' unless @headers['crit'].include?('b64')
+      end
     end
 
     def segments
       validate_claims!
-      combine(encoded_header_and_payload, encoded_signature)
+
+      parts = []
+      parts << encoded_header
+      parts << (@detached ? '' : encoded_payload)
+      parts << encoded_signature
+
+      combine(*parts)
     end
 
     private
@@ -51,7 +64,21 @@ module JWT
     end
 
     def encode_payload
-      encode_data(@payload)
+      # if b64 header is present and false, do not encode payload as per RFC7797 proposed standard
+      encode_payload? ? encode_data(@payload) : prepare_unencoded_payload
+    end
+
+    def encode_payload?
+      # if b64 header is left out, default to true as per RFC7797 proposed standard
+      @headers['b64'].nil? || !!@headers['b64']
+    end
+
+    def prepare_unencoded_payload
+      json = @payload.to_json
+
+      raise(JWT::InvalidUnencodedPayload, 'An unencoded payload cannot contain period/dot characters (i.e. ".").') if json.include?('.')
+
+      json
     end
 
     def signature

--- a/lib/jwt/error.rb
+++ b/lib/jwt/error.rb
@@ -5,6 +5,7 @@ module JWT
   class DecodeError < StandardError; end
   class RequiredDependencyError < StandardError; end
 
+  class InvalidUnencodedPayload < EncodeError; end
   class VerificationError < DecodeError; end
   class ExpiredSignature < DecodeError; end
   class IncorrectAlgorithm < DecodeError; end

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -2,6 +2,8 @@
 
 RSpec.describe JWT do
   let(:payload) { { 'user_id' => 'some@user.tld' } }
+  let(:non_encoded_payload) { { 'user_id' => 'safe_value' } }
+  let(:non_encoded_payload_unsafe) { { 'user_id' => 'unsafe.value' } }
 
   let :data do
     data = {
@@ -24,6 +26,8 @@ RSpec.describe JWT do
       'ES256K_public' => OpenSSL::PKey.read(File.read(File.join(CERT_PATH, 'ec256k-public.pem'))),
       'NONE' => 'eyJhbGciOiJub25lIn0.eyJ1c2VyX2lkIjoic29tZUB1c2VyLnRsZCJ9.',
       'HS256' => 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoic29tZUB1c2VyLnRsZCJ9.kWOVtIOpWcG7JnyJG0qOkTDbOy636XrrQhMm_8JrRQ8',
+      'HS256_non_encoded_payload' => 'eyJiNjQiOmZhbHNlLCJhbGciOiJIUzI1NiIsImNyaXQiOlsiYjY0Il19.{"user_id":"safe_value"}.eW4NSHANyJpL6ivfFut7a5CM5lpaif8vEQYr-CRzrUc',
+      'HS256_non_encoded_payload_detached' => 'eyJiNjQiOmZhbHNlLCJhbGciOiJIUzI1NiIsImNyaXQiOlsiYjY0Il19..eW4NSHANyJpL6ivfFut7a5CM5lpaif8vEQYr-CRzrUc',
       'HS512256' => 'eyJhbGciOiJIUzUxMjI1NiJ9.eyJ1c2VyX2lkIjoic29tZUB1c2VyLnRsZCJ9.Ds_4ibvf7z4QOBoKntEjDfthy3WJ-3rKMspTEcHE2bA',
       'HS384' => 'eyJhbGciOiJIUzM4NCJ9.eyJ1c2VyX2lkIjoic29tZUB1c2VyLnRsZCJ9.VuV4j4A1HKhWxCNzEcwc9qVF3frrEu-BRLzvYPkbWO0LENRGy5dOiBQ34remM3XH',
       'HS512' => 'eyJhbGciOiJIUzUxMiJ9.eyJ1c2VyX2lkIjoic29tZUB1c2VyLnRsZCJ9.8zNtCBTJIZTHpZ-BkhR-6sZY1K85Nm5YCKqV3AxRdsBJDt_RR-REH2db4T3Y0uQwNknhrCnZGvhNHrvhDwV1kA',
@@ -931,6 +935,42 @@ RSpec.describe JWT do
       it 'raises error on decoding' do
         expect { JWT.decode(expected_token, 'secret', true, algorithm: custom_algorithm.new) }.to raise_error(NoMethodError)
       end
+    end
+  end
+
+  context 'when payload is not encoded' do
+    it 'should generate a valid token' do
+      token = JWT.encode non_encoded_payload, data[:secret], 'HS256', { b64: false }
+
+      expect(token).to eq data['HS256_non_encoded_payload']
+    end
+
+    it 'should decode a valid token' do
+      jwt_payload, header = JWT.decode data['HS256_non_encoded_payload'], data[:secret], true, algorithm: 'HS256'
+
+      expect(header['alg']).to eq 'HS256'
+      expect(jwt_payload).to eq non_encoded_payload
+    end
+
+    it 'should raise error when payload is unsafe for decoding' do
+      expect do
+        JWT.encode non_encoded_payload_unsafe, 'secret', 'HS256', { b64: false }
+      end.to raise_error JWT::InvalidUnencodedPayload
+    end
+  end
+
+  context 'when payload is detached' do
+    it 'should generate a valid token' do
+      token = JWT.encode_detached non_encoded_payload, data[:secret], 'HS256', { b64: false }
+
+      expect(token).to eq data['HS256_non_encoded_payload_detached']
+    end
+
+    it 'should decode a valid token' do
+      jwt_payload, header = JWT.decode data['HS256_non_encoded_payload_detached'], data[:secret], true, algorithm: 'HS256', payload: non_encoded_payload
+
+      expect(header['alg']).to eq 'HS256'
+      expect(jwt_payload).to eq non_encoded_payload
     end
   end
 end


### PR DESCRIPTION
This adds support for RFC7797 and addresses https://github.com/jwt/ruby-jwt/issues/309

Here is the specification: https://www.rfc-editor.org/rfc/rfc7797

Happy to receive feedback and would love to get this released soon as I need it for my current project.

