### PR TITLE
Do not raise error when verifying bad HMAC signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 **Fixes and enhancements:**
 
 - Handle invalid algorithm when decoding JWT [#559](https://github.com/jwt/ruby-jwt/pull/559) - [@nataliastanko](https://github.com/nataliastanko)
+- Do not raise error when verifying bad HMAC signature [#563](https://github.com/jwt/ruby-jwt/pull/563) - [@hieuk09](https://github.com/hieuk09)
 - Your contribution here
 
 ## [v2.7.0](https://github.com/jwt/ruby-jwt/tree/v2.7.0) (2023-02-01)

--- a/lib/jwt/algos/hmac_rbnacl.rb
+++ b/lib/jwt/algos/hmac_rbnacl.rb
@@ -28,7 +28,7 @@ module JWT
         else
           Hmac.verify(algorithm, key, signing_input, signature)
         end
-      rescue ::RbNaCl::BadAuthenticatorError
+      rescue ::RbNaCl::BadAuthenticatorError, ::RbNaCl::LengthError
         false
       end
 

--- a/lib/jwt/algos/hmac_rbnacl_fixed.rb
+++ b/lib/jwt/algos/hmac_rbnacl_fixed.rb
@@ -36,7 +36,7 @@ module JWT
         else
           Hmac.verify(algorithm, key, signing_input, signature)
         end
-      rescue ::RbNaCl::BadAuthenticatorError
+      rescue ::RbNaCl::BadAuthenticatorError, ::RbNaCl::LengthError
         false
       end
 

--- a/spec/jwt/algos/hmac_rbnacl_fixed_spec.rb
+++ b/spec/jwt/algos/hmac_rbnacl_fixed_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe '::JWT::Algos::HmacRbNaClFixed' do
         expect(OpenSSL::HMAC).to have_received(:digest).once
       end
     end
+
+    context 'when signature is invalid' do
+      let(:key) { 'a' * 100 }
+      let(:signature) { JWT::Base64.url_decode('some_random_signature') }
+
+      it 'can verify without error' do
+        allow(OpenSSL::HMAC).to receive(:digest).and_call_original
+        expect(described_class.verify('HS256', key, data, signature)).to eq(false)
+        expect(OpenSSL::HMAC).not_to have_received(:digest)
+      end
+    end
   end
 
   describe '.sign' do

--- a/spec/jwt/algos/hmac_rbnacl_spec.rb
+++ b/spec/jwt/algos/hmac_rbnacl_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe '::JWT::Algos::HmacRbNaCl' do
         expect(OpenSSL::HMAC).not_to have_received(:digest)
       end
     end
+
+    context 'when signature is invalid' do
+      let(:key) { 'a' * 100 }
+      let(:signature) { JWT::Base64.url_decode('some_random_signature') }
+
+      it 'can verify without error' do
+        allow(OpenSSL::HMAC).to receive(:digest).and_call_original
+        expect(described_class.verify('HS256', key, data, signature)).to eq(false)
+        expect(OpenSSL::HMAC).not_to have_received(:digest)
+      end
+    end
   end
 
   describe '.sign' do


### PR DESCRIPTION
Currently, if user inputs token with incorrect signature (example: a part of signature is missing because it was truncated), an error is raised. It can be reproduced using the code below:

```ruby
data = 'a string to be encoded'
key = 'a secret'
token = JWT.encode(data, key, 'HS256')
new_token = token[0..-2]
JWT.decode(new_token, key, true, algorithm: 'HS256') # raise error Provided authenticator was 31 bytes (Expected 32) (RbNaCl::LengthError)
```

It would be great if `Signature verification failed (JWT::VerificationError)` is raised in this case