### PR TITLE
Fix key base equality and spaceship operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 **Fixes and enhancements:**
 
 - Fix signature has expired error if payload is a string [#555](https://github.com/jwt/ruby-jwt/pull/555) - [@GobinathAL](https://github.com/GobinathAL).
+- Fix key base equality and spaceship operators [#569](https://github.com/jwt/ruby-jwt/pull/569) - [@magneland](https://github.com/magneland).
 - Your contribution here
 
 ## [v2.7.1](https://github.com/jwt/ruby-jwt/tree/v2.8.0) (2023-06-09)

--- a/lib/jwt/jwk/key_base.rb
+++ b/lib/jwt/jwk/key_base.rb
@@ -38,7 +38,7 @@ module JWT
       end
 
       def ==(other)
-        self[:kid] == other[:kid]
+        other.is_a?(::JWT::JWK::KeyBase) && self[:kid] == other[:kid]
       end
 
       alias eql? ==

--- a/lib/jwt/jwk/key_base.rb
+++ b/lib/jwt/jwk/key_base.rb
@@ -44,6 +44,8 @@ module JWT
       alias eql? ==
 
       def <=>(other)
+        return nil unless other.is_a?(::JWT::JWK::KeyBase)
+
         self[:kid] <=> other[:kid]
       end
 

--- a/spec/jwk/hmac_spec.rb
+++ b/spec/jwk/hmac_spec.rb
@@ -82,4 +82,36 @@ RSpec.describe JWT::JWK::HMAC do
       end
     end
   end
+
+  describe '#==' do
+    it 'is equal to itself' do
+      other = jwk
+      expect(jwk == other).to eq true
+    end
+
+    it 'is equal to a clone of itself' do
+      other = jwk.clone
+      expect(jwk == other).to eq true
+    end
+
+    it 'is not equal to nil' do
+      other = nil
+      expect(jwk == other).to eq false
+    end
+
+    it 'is not equal to boolean true' do
+      other = true
+      expect(jwk == other).to eq false
+    end
+
+    it 'is not equal to a non-key' do
+      other = Object.new
+      expect(jwk == other).to eq false
+    end
+
+    it 'is not equal to a different key' do
+      other = described_class.new('other-key')
+      expect(jwk == other).to eq false
+    end
+  end
 end

--- a/spec/jwk/hmac_spec.rb
+++ b/spec/jwk/hmac_spec.rb
@@ -114,4 +114,36 @@ RSpec.describe JWT::JWK::HMAC do
       expect(jwk == other).to eq false
     end
   end
+
+  describe '#<=>' do
+    it 'is equal to itself' do
+      other = jwk
+      expect(jwk <=> other).to eq 0
+    end
+
+    it 'is equal to a clone of itself' do
+      other = jwk.clone
+      expect(jwk <=> other).to eq 0
+    end
+
+    it 'is not comparable to nil' do
+      other = nil
+      expect(jwk <=> other).to eq nil
+    end
+
+    it 'is not comparable to boolean true' do
+      other = true
+      expect(jwk <=> other).to eq nil
+    end
+
+    it 'is not comparable to a non-key' do
+      other = Object.new
+      expect(jwk <=> other).to eq nil
+    end
+
+    it 'is not equal to a different key' do
+      other = described_class.new('other-key')
+      expect(jwk <=> other).not_to eq 0
+    end
+  end
 end


### PR DESCRIPTION
I ran into this issue when trying to use `Rails.cache.fetch`.

Specifically there is a [fallback condition](https://github.com/rails/rails/blob/6-1-stable/activesupport/lib/active_support/cache.rb#L837) that tried to compare:

`@value == true` (where `@value` was a JWK)

and this gem raised an error:

```
undefined method `[]' for true:TrueClass
```

I haven't run into the spaceship operator issue, but I figured it is similar enough to fix at the same time.
