### PR TITLE
Drop use of base64 gem and warn about invalid base64 input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Fix key base equality and spaceship operators [#569](https://github.com/jwt/ruby-jwt/pull/569) - [@magneland](https://github.com/magneland).
 - Remove explicit base64 require from x5c_key_finder [#580](https://github.com/jwt/ruby-jwt/pull/580) - [@anakinj](https://github.com/anakinj).
 - Performance improvements and cleanup of tests [#581](https://github.com/jwt/ruby-jwt/pull/581) - [@anakinj](https://github.com/anakinj).
+- Drop dependency to base64 gem [#578](https://github.com/jwt/ruby-jwt/pull/578) - [@anakinj](https://github.com/anakinj).
+- Deprecation warning for decoding content not compliant with RFC 4648 [#578](https://github.com/jwt/ruby-jwt/pull/578) - [@anakinj](https://github.com/anakinj).
 - Your contribution here
 
 ## [v2.7.1](https://github.com/jwt/ruby-jwt/tree/v2.8.0) (2023-06-09)

--- a/lib/jwt/base64.rb
+++ b/lib/jwt/base64.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 
-require 'base64'
-
 module JWT
-  # Base64 helpers
+  # Base64 encoding and decoding
   class Base64
     class << self
+      # Encode a string with URL-safe Base64 complying with RFC 4648 (not padded).
       def url_encode(str)
-        ::Base64.encode64(str).tr('+/', '-_').gsub(/[\n=]/, '')
+        encoded = [str].pack('m0')
+        encoded.chomp!('==') || encoded.chomp!('=')
+        encoded.tr!('+/', '-_')
+        encoded
       end
 
+      # Decode a string with URL-safe Base64 complying with RFC 4648.
+      # Deprecated support for RFC 2045 remains for now. ("All line breaks or other characters not found in Table 1 must be ignored by decoding software")
       def url_decode(str)
-        str += '=' * (4 - str.length.modulo(4))
-        ::Base64.decode64(str.tr('-_', '+/'))
+        if !str.end_with?('=') && str.length % 4 != 0
+          str = str.ljust((str.length + 3) & ~3, '=')
+          str.tr!('-_', '+/')
+        else
+          str = str.tr('-_', '+/')
+        end
+        str.unpack1('m0')
+      rescue ArgumentError => e
+        raise unless e.message == 'invalid base64'
+
+        warn('[DEPRECATION] Invalid base64 input detected, could be because of invalid padding, trailing whitespaces or newline chars. Graceful handling of invalid input will be dropped in the next major version of ruby-jwt')
+        str.unpack1('m')
       end
     end
   end

--- a/spec/jwt/x5c_key_finder_spec.rb
+++ b/spec/jwt/x5c_key_finder_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe JWT::X5cKeyFinder do
 
   let(:crl) { issue_crl([], issuer: root_certificate, issuer_key: root_key) }
 
-  let(:x5c_header) { [Base64.strict_encode64(leaf_certificate.to_der)] }
+  let(:x5c_header) { [JWT::Base64.encode64(leaf_certificate.to_der)] }
   subject(:keyfinder) { described_class.new([root_certificate], [crl]).from(x5c_header) }
 
   it 'returns the public key from a certificate that is signed by trusted roots and not revoked' do


### PR DESCRIPTION
### Description

This pull request removes the dependency to the base64 gem. Motivation for this is the warnings emitting if `base64` is not in the Gemfile/gemspec of the component running it, this is something that is a thing in Ruby 3.3 forward([ref](https://github.com/ruby/ruby/blob/ruby_3_3/NEWS.md#stdlib-updates)). Another approach would be to list base64 as a dependency to in the .gemspec, but I kinda like the control of the Base64 handling. Maybe in the future we can remove the custom logic.

A bit of base64 history:

#483
#551 


This approach also allows nicer way to deprecate support for the looser base64 that is baked into RFC 2045

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
