### PR TITLE
Remove base64 require from x5c keyfinder implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fix signature has expired error if payload is a string [#555](https://github.com/jwt/ruby-jwt/pull/555) - [@GobinathAL](https://github.com/GobinathAL).
 - Fix key base equality and spaceship operators [#569](https://github.com/jwt/ruby-jwt/pull/569) - [@magneland](https://github.com/magneland).
+- Remove explicit base64 require from x5c_key_finder [#580](https://github.com/jwt/ruby-jwt/pull/580) - [@anakinj](https://github.com/anakinj).
 - Your contribution here
 
 ## [v2.7.1](https://github.com/jwt/ruby-jwt/tree/v2.8.0) (2023-06-09)

--- a/lib/jwt/x5c_key_finder.rb
+++ b/lib/jwt/x5c_key_finder.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'base64'
-require 'jwt/error'
-
 module JWT
   # If the x5c header certificate chain can be validated by trusted root
   # certificates, and none of the certificates are revoked, returns the public

--- a/spec/x5c_key_finder_spec.rb
+++ b/spec/x5c_key_finder_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'jwt/x5c_key_finder'
-
 describe JWT::X5cKeyFinder do
   let(:root_key) { OpenSSL::PKey.read(File.read(File.join(CERT_PATH, 'rsa-2048-private.pem'))) }
   let(:root_dn) { OpenSSL::X509::Name.parse('/DC=org/DC=fake-ca/CN=Fake CA') }


### PR DESCRIPTION
### Description

This Pull Request changes/fixes this thing

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
