### PR TITLE
Deprecate the loose base64 decoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Remove explicit base64 require from x5c_key_finder [#580](https://github.com/jwt/ruby-jwt/pull/580) - [@anakinj](https://github.com/anakinj).
 - Performance improvements and cleanup of tests [#581](https://github.com/jwt/ruby-jwt/pull/581) - [@anakinj](https://github.com/anakinj).
 - Repair EC x/y coordinates when importing JWK [#585](https://github.com/jwt/ruby-jwt/pull/585) - [@julik](https://github.com/julik).
+- Explicit dependency to the base64 gem [#582](https://github.com/jwt/ruby-jwt/pull/582) - [@anakinj](https://github.com/anakinj).
+- Deprecation warning for decoding content not compliant with RFC 4648 [#582](https://github.com/jwt/ruby-jwt/pull/582) - [@anakinj](https://github.com/anakinj).
 - Your contribution here
 
 ## [v2.7.1](https://github.com/jwt/ruby-jwt/tree/v2.8.0) (2023-06-09)

--- a/lib/jwt/base64.rb
+++ b/lib/jwt/base64.rb
@@ -3,14 +3,26 @@
 require 'base64'
 
 module JWT
-  # Base64 helpers
+  # Base64 encoding and decoding
   class Base64
     class << self
+      # Encode a string with URL-safe Base64 complying with RFC 4648 (not padded).
       def url_encode(str)
-        ::Base64.encode64(str).tr('+/', '-_').gsub(/[\n=]/, '')
+        ::Base64.urlsafe_encode64(str, padding: false)
       end
 
+      # Decode a string with URL-safe Base64 complying with RFC 4648.
+      # Deprecated support for RFC 2045 remains for now. ("All line breaks or other characters not found in Table 1 must be ignored by decoding software")
       def url_decode(str)
+        ::Base64.urlsafe_decode64(str)
+      rescue ArgumentError => e
+        raise unless e.message == 'invalid base64'
+
+        warn('[DEPRECATION] Invalid base64 input detected, could be because of invalid padding, trailing whitespaces or newline chars. Graceful handling of invalid input will be dropped in the next major version of ruby-jwt')
+        loose_urlsafe_decode64(str)
+      end
+
+      def loose_urlsafe_decode64(str)
         str += '=' * (4 - str.length.modulo(4))
         ::Base64.decode64(str.tr('-_', '+/'))
       end

--- a/ruby-jwt.gemspec
+++ b/ruby-jwt.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |spec|
   spec.executables = []
   spec.require_paths = %w[lib]
 
+  spec.add_dependency 'base64'
+
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
### Description

I first started by implementing the base64 methods within the gem (#578), but that did not really make sense in the end and there was already a bunch of direct references to the Base64 module.

This PR:
- Adds a dependency to the base64 gem and makes the dependency handling compatible with future Ruby versions.
- Warns about base64 payloads with invalid content (RFC 2045). Support for this will be dropped in later versions.

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
