### PR TITLE
Adjust to changed exception message

### DIFF
--- a/spec/jwt/jwk/decode_with_jwk_spec.rb
+++ b/spec/jwt/jwk/decode_with_jwk_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe JWT do
 
         it 'fails in some way' do
           expect { described_class.decode(signed_token, nil, true, algorithms: [algorithm], jwks: jwks) }.to(
-            raise_error(NoMethodError, /undefined method `verify' for/)
+            raise_error(NoMethodError, /undefined method .*verify/)
           )
         end
       end
@@ -148,7 +148,7 @@ RSpec.describe JWT do
 
         it 'fails in some way' do
           expect { described_class.decode(signed_token, nil, true, algorithms: ['ES384'], jwks: jwks) }.to(
-            raise_error(NoMethodError, /undefined method `group' for/)
+            raise_error(NoMethodError, /undefined method .*group/)
           )
         end
       end


### PR DESCRIPTION
### Description

The message for NoMethodError has changed. This PR adjust the test to be compatible with those changes.

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [ ] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
