### PR TITLE
Only issue invalid base64 warning on successful decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Features:**
 
+- Print deprecation warnings only on when token decoding succeeds [#601](https://github.com/jwt/ruby-jwt/pull/601) ([@jeremyevans](https://github.com/jeremyevans))
 - Your contribution here
 
 **Fixes and enhancements:**

--- a/lib/jwt/base64.rb
+++ b/lib/jwt/base64.rb
@@ -19,9 +19,7 @@ module JWT
         raise unless e.message == 'invalid base64'
         raise Base64DecodeError, 'Invalid base64 encoding' if JWT.configuration.strict_base64_decoding
 
-        loose_urlsafe_decode64(str).tap do
-          Deprecations.warning('Invalid base64 input detected, could be because of invalid padding, trailing whitespaces or newline chars. Graceful handling of invalid input will be dropped in the next major version of ruby-jwt')
-        end
+        loose_urlsafe_decode64(str)
       end
 
       def loose_urlsafe_decode64(str)

--- a/spec/jwt/jwt_spec.rb
+++ b/spec/jwt/jwt_spec.rb
@@ -944,4 +944,23 @@ RSpec.describe JWT do
       end
     end
   end
+
+  context 'when invalid token is valid loose base64' do
+    it 'does not output deprecations warnings' do
+      expect {
+        2.times do
+          JWT.decode("#{JWT.encode('a', 'b')} 9", 'b')
+        rescue JWT::VerificationError
+          nil
+        end
+        JWT.decode(JWT.encode('a', 'b'), 'b')
+      }.not_to output(/DEPRECATION/).to_stderr
+    end
+  end
+
+  context 'when valid token is invalid strict base64' do
+    it 'does outputs deprecation warning' do
+      expect { JWT.decode("#{JWT.encode('a', 'b')} ", 'b') }.to output(/DEPRECATION/).to_stderr
+    end
+  end
 end


### PR DESCRIPTION
### Description

To make the patch minimally invasive, this attempts to decode the given jwt in strict base64 mode only after a successful full decode and validation.

Most jwts are small, so this should have minimal performance impact, though it does require decoding twice.  It is possible to fix the issue and only decode once, but it would be more invasive.

A big advantage of this approach is the use of :uplevel when calling Kernel#warn, so that the calling location that triggers the warning is included in the warning message, greatly simplifying debugging.

### Checklist

Before the PR can be merged be sure the following are checked:
* [X] There are tests for the fix or feature added/changed
* [X] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
