### PR TITLE
Dynamically register algorithms to lookup as they get loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Fixes and enhancements:**
 
 - Refactor claim validators into their own classes [#605](https://github.com/jwt/ruby-jwt/pull/605) ([@anakinj](https://github.com/anakinj), [@MatteoPierro](https://github.com/MatteoPierro))
+- Allow extending available algorithms [#607](https://github.com/jwt/ruby-jwt/pull/607) ([@anakinj](https://github.com/anakinj))
 - Your contribution here
 
 ## [v2.8.2](https://github.com/jwt/ruby-jwt/tree/v2.8.2) (2024-06-18)

--- a/README.md
+++ b/README.md
@@ -223,16 +223,20 @@ puts decoded_token
 
 ### **Custom algorithms**
 
-An object implementing custom signing or verification behaviour can be passed in the `algorithm` option when encoding and decoding. The given object needs to implement the method `valid_alg?` and `verify` and/or `alg` and `sign`, depending if object is used for encoding or decoding.
+When encoding or decoding a token, you can pass in a custom object through the `algorithm` option to handle signing or verification. This custom object must include or extend the `JWT::JWA::SigningAlgorithm` module and implement certain methods:
+
+- For decoding/verifying: The object must implement the methods `alg` and `verify`.
+- For encoding/signing: The object must implement the methods `alg` and `sign`.
+
+For customization options check the details from `JWT::JWA::SigningAlgorithm`.
+
 
 ```ruby
 module CustomHS512Algorithm
+  extend JWT::JWA::SigningAlgorithm
+
   def self.alg
     'HS512'
-  end
-
-  def self.valid_alg?(alg_to_validate)
-    alg_to_validate == alg
   end
 
   def self.sign(data:, signing_key:)

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -90,7 +90,7 @@ module JWT
     end
 
     def resolve_allowed_algorithms
-      algs = given_algorithms.map { |alg| JWA.create(alg) }
+      algs = given_algorithms.map { |alg| JWA.resolve(alg) }
 
       sort_by_alg_header(algs)
     end

--- a/lib/jwt/encode.rb
+++ b/lib/jwt/encode.rb
@@ -6,14 +6,11 @@ require_relative 'jwa'
 module JWT
   # Encoding logic for JWT
   class Encode
-    ALG_KEY = 'alg'
-
     def initialize(options)
       @payload          = options[:payload]
       @key              = options[:key]
-      @algorithm        = JWA.create(options[:algorithm])
+      @algorithm        = JWA.resolve(options[:algorithm])
       @headers          = options[:headers].transform_keys(&:to_s)
-      @headers[ALG_KEY] = @algorithm.alg
     end
 
     def segments
@@ -40,7 +37,7 @@ module JWT
     end
 
     def encode_header
-      encode_data(@headers)
+      encode_data(@headers.merge(@algorithm.header(signing_key: @key)))
     end
 
     def encode_payload

--- a/lib/jwt/jwa.rb
+++ b/lib/jwt/jwa.rb
@@ -8,54 +8,35 @@ rescue LoadError
   raise if defined?(RbNaCl)
 end
 
-require_relative 'jwa/hmac'
-require_relative 'jwa/eddsa'
+require_relative 'jwa/signing_algorithm'
+
 require_relative 'jwa/ecdsa'
-require_relative 'jwa/rsa'
-require_relative 'jwa/ps'
+require_relative 'jwa/eddsa'
+require_relative 'jwa/hmac'
 require_relative 'jwa/none'
+require_relative 'jwa/ps'
+require_relative 'jwa/rsa'
 require_relative 'jwa/unsupported'
 require_relative 'jwa/wrapper'
 
+if JWT.rbnacl_6_or_greater?
+  require_relative 'jwa/hmac_rbnacl'
+elsif JWT.rbnacl?
+  require_relative 'jwa/hmac_rbnacl_fixed'
+end
+
 module JWT
   module JWA
-    ALGOS = [Hmac, Ecdsa, Rsa, Eddsa, Ps, None, Unsupported].tap do |l|
-      if ::JWT.rbnacl_6_or_greater?
-        require_relative 'jwa/hmac_rbnacl'
-        l << Algos::HmacRbNaCl
-      elsif ::JWT.rbnacl?
-        require_relative 'jwa/hmac_rbnacl_fixed'
-        l << Algos::HmacRbNaClFixed
-      end
-    end.freeze
-
     class << self
-      def find(algorithm)
-        indexed[algorithm&.downcase]
-      end
+      def resolve(algorithm)
+        return find(algorithm) if algorithm.is_a?(String) || algorithm.is_a?(Symbol)
 
-      def create(algorithm)
-        return algorithm if JWA.implementation?(algorithm)
-
-        Wrapper.new(*find(algorithm))
-      end
-
-      def implementation?(algorithm)
-        (algorithm.respond_to?(:valid_alg?) && algorithm.respond_to?(:verify)) ||
-          (algorithm.respond_to?(:alg) && algorithm.respond_to?(:sign))
-      end
-
-      private
-
-      def indexed
-        @indexed ||= begin
-          fallback = [nil, Unsupported]
-          ALGOS.each_with_object(Hash.new(fallback)) do |cls, hash|
-            cls.const_get(:SUPPORTED).each do |alg|
-              hash[alg.downcase] = [alg, cls]
-            end
-          end
+        unless algorithm.is_a?(SigningAlgorithm)
+          Deprecations.warning('Custom algorithms are required to include JWT::JWA::SigningAlgorithm')
+          return Wrapper.new(algorithm)
         end
+
+        algorithm
       end
     end
   end

--- a/lib/jwt/jwa/eddsa.rb
+++ b/lib/jwt/jwa/eddsa.rb
@@ -2,41 +2,33 @@
 
 module JWT
   module JWA
-    module Eddsa
-      SUPPORTED = %w[ED25519 EdDSA].freeze
-      SUPPORTED_DOWNCASED = SUPPORTED.map(&:downcase).freeze
+    class Eddsa
+      include JWT::JWA::SigningAlgorithm
 
-      class << self
-        def sign(algorithm, msg, key)
-          unless key.is_a?(RbNaCl::Signatures::Ed25519::SigningKey)
-            raise EncodeError, "Key given is a #{key.class} but has to be an RbNaCl::Signatures::Ed25519::SigningKey"
-          end
-
-          validate_algorithm!(algorithm)
-
-          key.sign(msg)
-        end
-
-        def verify(algorithm, public_key, signing_input, signature)
-          unless public_key.is_a?(RbNaCl::Signatures::Ed25519::VerifyKey)
-            raise DecodeError, "key given is a #{public_key.class} but has to be a RbNaCl::Signatures::Ed25519::VerifyKey"
-          end
-
-          validate_algorithm!(algorithm)
-
-          public_key.verify(signature, signing_input)
-        rescue RbNaCl::CryptoError
-          false
-        end
-
-        private
-
-        def validate_algorithm!(algorithm)
-          return if SUPPORTED_DOWNCASED.include?(algorithm.downcase)
-
-          raise IncorrectAlgorithm, "Algorithm #{algorithm} not supported. Supported algoritms are #{SUPPORTED.join(', ')}"
-        end
+      def initialize(alg)
+        @alg = alg
       end
+
+      def sign(data:, signing_key:)
+        unless signing_key.is_a?(RbNaCl::Signatures::Ed25519::SigningKey)
+          raise_encode_error!("Key given is a #{signing_key.class} but has to be an RbNaCl::Signatures::Ed25519::SigningKey")
+        end
+
+        signing_key.sign(data)
+      end
+
+      def verify(data:, signature:, verification_key:)
+        unless verification_key.is_a?(RbNaCl::Signatures::Ed25519::VerifyKey)
+          raise_decode_error!("key given is a #{verification_key.class} but has to be a RbNaCl::Signatures::Ed25519::VerifyKey")
+        end
+
+        verification_key.verify(signature, data)
+      rescue RbNaCl::CryptoError
+        false
+      end
+
+      register_algorithm(new('ED25519'))
+      register_algorithm(new('EdDSA'))
     end
   end
 end

--- a/lib/jwt/jwa/none.rb
+++ b/lib/jwt/jwa/none.rb
@@ -2,10 +2,12 @@
 
 module JWT
   module JWA
-    module None
-      module_function
+    class None
+      include JWT::JWA::SigningAlgorithm
 
-      SUPPORTED = %w[none].freeze
+      def initialize
+        @alg = 'none'
+      end
 
       def sign(*)
         ''
@@ -14,6 +16,8 @@ module JWT
       def verify(*)
         true
       end
+
+      register_algorithm(new)
     end
   end
 end

--- a/lib/jwt/jwa/rsa.rb
+++ b/lib/jwt/jwa/rsa.rb
@@ -2,24 +2,35 @@
 
 module JWT
   module JWA
-    module Rsa
-      module_function
+    class Rsa
+      include JWT::JWA::SigningAlgorithm
 
-      SUPPORTED = %w[RS256 RS384 RS512].freeze
-
-      def sign(algorithm, msg, key)
-        unless key.is_a?(OpenSSL::PKey::RSA)
-          raise EncodeError, "The given key is a #{key.class}. It has to be an OpenSSL::PKey::RSA instance"
-        end
-
-        key.sign(OpenSSL::Digest.new(algorithm.sub('RS', 'sha')), msg)
+      def initialize(alg)
+        @alg = alg
+        @digest = OpenSSL::Digest.new(alg.sub('RS', 'SHA'))
       end
 
-      def verify(algorithm, public_key, signing_input, signature)
-        public_key.verify(OpenSSL::Digest.new(algorithm.sub('RS', 'sha')), signature, signing_input)
+      def sign(data:, signing_key:)
+        unless signing_key.is_a?(OpenSSL::PKey::RSA)
+          raise_sign_error!("The given key is a #{signing_key.class}. It has to be an OpenSSL::PKey::RSA instance")
+        end
+
+        signing_key.sign(digest, data)
+      end
+
+      def verify(data:, signature:, verification_key:)
+        verification_key.verify(digest, signature, data)
       rescue OpenSSL::PKey::PKeyError
         raise JWT::VerificationError, 'Signature verification raised'
       end
+
+      register_algorithm(new('RS256'))
+      register_algorithm(new('RS384'))
+      register_algorithm(new('RS512'))
+
+      private
+
+      attr_reader :digest
     end
   end
 end

--- a/lib/jwt/jwa/signing_algorithm.rb
+++ b/lib/jwt/jwa/signing_algorithm.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module JWT
+  module JWA
+    module SigningAlgorithm
+      module ClassMethods
+        def register_algorithm(algo)
+          ::JWT::JWA.register_algorithm(algo)
+        end
+      end
+
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      attr_reader :alg
+
+      def valid_alg?(alg_to_check)
+        alg&.casecmp(alg_to_check)&.zero? == true
+      end
+
+      def header(*)
+        { 'alg' => alg }
+      end
+
+      def sign(*)
+        raise_sign_error!('Algorithm implementation is missing the sign method')
+      end
+
+      def verify(*)
+        raise_verify_error!('Algorithm implementation is missing the verify method')
+      end
+
+      def raise_verify_error!(message)
+        raise(DecodeError.new(message).tap { |e| e.set_backtrace(caller(1)) })
+      end
+
+      def raise_sign_error!(message)
+        raise(EncodeError.new(message).tap { |e| e.set_backtrace(caller(1)) })
+      end
+    end
+
+    class << self
+      def register_algorithm(algo)
+        algorithms[algo.alg.to_s.downcase] = algo
+      end
+
+      def find(algo)
+        algorithms.fetch(algo.to_s.downcase, Unsupported)
+      end
+
+      private
+
+      def algorithms
+        @algorithms ||= {}
+      end
+    end
+  end
+end

--- a/lib/jwt/jwa/unsupported.rb
+++ b/lib/jwt/jwa/unsupported.rb
@@ -3,16 +3,16 @@
 module JWT
   module JWA
     module Unsupported
-      module_function
+      class << self
+        include JWT::JWA::SigningAlgorithm
 
-      SUPPORTED = [].freeze
+        def sign(*)
+          raise_sign_error!('Unsupported signing method')
+        end
 
-      def sign(*)
-        raise NotImplementedError, 'Unsupported signing method'
-      end
-
-      def verify(*)
-        raise JWT::VerificationError, 'Algorithm not supported'
+        def verify(*)
+          raise JWT::VerificationError, 'Algorithm not supported'
+        end
       end
     end
   end

--- a/lib/jwt/jwa/wrapper.rb
+++ b/lib/jwt/jwa/wrapper.rb
@@ -3,23 +3,40 @@
 module JWT
   module JWA
     class Wrapper
-      attr_reader :alg, :cls
+      include SigningAlgorithm
 
-      def initialize(alg, cls)
-        @alg = alg
-        @cls = cls
+      def initialize(algorithm)
+        @algorithm = algorithm
+      end
+
+      def alg
+        return @algorithm.alg if @algorithm.respond_to?(:alg)
+
+        super
       end
 
       def valid_alg?(alg_to_check)
-        alg&.casecmp(alg_to_check)&.zero? == true
+        return @algorithm.valid_alg?(alg_to_check) if @algorithm.respond_to?(:valid_alg?)
+
+        super
       end
 
-      def sign(data:, signing_key:)
-        cls.sign(alg, data, signing_key)
+      def header(*args, **kwargs)
+        return @algorithm.header(*args, **kwargs) if @algorithm.respond_to?(:header)
+
+        super
       end
 
-      def verify(data:, signature:, verification_key:)
-        cls.verify(alg, verification_key, data, signature)
+      def sign(*args, **kwargs)
+        return @algorithm.sign(*args, **kwargs) if @algorithm.respond_to?(:sign)
+
+        super
+      end
+
+      def verify(*args, **kwargs)
+        return @algorithm.verify(*args, **kwargs) if @algorithm.respond_to?(:verify)
+
+        super
       end
     end
   end

--- a/spec/integration/readme_examples_spec.rb
+++ b/spec/integration/readme_examples_spec.rb
@@ -451,12 +451,10 @@ RSpec.describe 'README.md code test' do
   context 'custom algorithm example' do
     it 'allows a module to be used as algorithm on encode and decode' do
       custom_hs512_alg = Module.new do
+        extend JWT::JWA::SigningAlgorithm
+
         def self.alg
           'HS512'
-        end
-
-        def self.valid_alg?(alg_to_validate)
-          alg_to_validate == alg
         end
 
         def self.sign(data:, signing_key:)
@@ -469,7 +467,8 @@ RSpec.describe 'README.md code test' do
       end
 
       token = JWT.encode({ 'pay' => 'load' }, 'secret', custom_hs512_alg)
-      _payload, _header = JWT.decode(token, 'secret', true, algorithm: custom_hs512_alg)
+      _payload, header = JWT.decode(token, 'secret', true, algorithm: custom_hs512_alg)
+      expect(header).to include('alg' => 'HS512')
     end
   end
 end

--- a/spec/jwt/jwa/hmac_rbnacl_fixed_spec.rb
+++ b/spec/jwt/jwa/hmac_rbnacl_fixed_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe 'JWT::JWA::HmacRbNaClFixed' do
+  subject(:instance) { JWT::JWA::HmacRbNaClFixed.new('HS512256', RbNaCl::HMAC::SHA512256) }
+  let(:data) { 'test' }
+
+  before do
+    skip('Requires the rbnacl gem') unless JWT.rbnacl? && !JWT.rbnacl_6_or_greater?
+  end
+
+  describe '#sign' do
+    subject(:sign) { instance.sign(data: data, signing_key: signing_key) }
+
+    let(:signing_key) { '*' * (RbNaCl::HMAC::SHA512256.key_bytes - 1) }
+
+    it { is_expected.not_to be_empty }
+
+    context 'when signing_key key is larger than hmac key bytes' do
+      let(:signing_key) { '*' * (RbNaCl::HMAC::SHA512256.key_bytes + 1) }
+
+      it 'raises length error' do
+        expect { sign }.to raise_error(RbNaCl::LengthError, a_string_including('key was 33 bytes (Expected 32)'))
+      end
+    end
+  end
+
+  describe '#verify' do
+    subject(:verify) { instance.verify(data: data, signature: signature, verification_key: verification_key) }
+
+    let(:signature) { instance.sign(data: data, signing_key: signing_key) }
+
+    let(:verification_key) { '*' * (RbNaCl::HMAC::SHA512256.key_bytes - 1) }
+    let(:signing_key) { verification_key }
+
+    it { is_expected.to be(true) }
+
+    context 'when verification_key key is larger than hmac key bytes' do
+      let(:verification_key) { '*' * (RbNaCl::HMAC::SHA512256.key_bytes + 1) }
+      let(:signature) { 'a_signature' }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/jwt/jwa/hmac_spec.rb
+++ b/spec/jwt/jwa/hmac_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe JWT::JWA::Hmac do
-  describe '.sign' do
-    subject { described_class.sign('HS256', 'test', hmac_secret) }
+  let(:instance) { described_class.new('HS256', OpenSSL::Digest::SHA256) }
+
+  describe '#sign' do
+    subject { instance.sign(data: 'test', signing_key: hmac_secret) }
 
     # Address OpenSSL 3.0 errors with empty hmac_secret - https://github.com/jwt/ruby-jwt/issues/526
     context 'when nil hmac_secret is passed' do


### PR DESCRIPTION
### Description

Dynamically generate the list of supported algorithms as implementations are loaded. This will allow replacing and extending the algorithm from outside of this gem.

Initial use-case would be to move the rbnacl related algorithms to a gem with an explicit dependency to the 3rd party crypto libs. More of that work can be looked at over [here](https://github.com/anakinj/jwt-eddsa)

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
