### PR TITLE
Fix verify_iss and verify_aud when no expected values are passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Fixes and enhancements:**
 
+- Fix regression in `iss` and `aud` claim validation [#619](https://github.com/jwt/ruby-jwt/pull/619) ([@anakinj](https://github.com/anakinj))
 - Your contribution here
 
 ## [v2.9.0](https://github.com/jwt/ruby-jwt/tree/v2.9.0) (2024-09-15)

--- a/lib/jwt/claims.rb
+++ b/lib/jwt/claims.rb
@@ -17,10 +17,10 @@ module JWT
     VERIFIERS = {
       verify_expiration: ->(options) { Claims::Expiration.new(leeway: options[:exp_leeway] || options[:leeway]) },
       verify_not_before: ->(options) { Claims::NotBefore.new(leeway: options[:nbf_leeway] || options[:leeway]) },
-      verify_iss: ->(options) { Claims::Issuer.new(issuers: options[:iss]) },
+      verify_iss: ->(options) { options[:iss] && Claims::Issuer.new(issuers: options[:iss]) },
       verify_iat: ->(*) { Claims::IssuedAt.new },
       verify_jti: ->(options) { Claims::JwtId.new(validator: options[:verify_jti]) },
-      verify_aud: ->(options) { Claims::Audience.new(expected_audience: options[:aud]) },
+      verify_aud: ->(options) { options[:aud] && Claims::Audience.new(expected_audience: options[:aud]) },
       verify_sub: ->(options) { options[:sub] && Claims::Subject.new(expected_subject: options[:sub]) },
       required_claims: ->(options) { Claims::Required.new(required_claims: options[:required_claims]) }
     }.freeze

--- a/spec/jwt/jwt_spec.rb
+++ b/spec/jwt/jwt_spec.rb
@@ -538,10 +538,31 @@ RSpec.describe JWT do
         iss_payload = payload.merge(iss: iss)
         JWT.encode iss_payload, data[:secret]
       end
+
       it 'if verify_iss is set to false (default option) should not raise JWT::InvalidIssuerError' do
         expect do
           JWT.decode token, data[:secret], true, iss: iss, algorithm: 'HS256'
         end.not_to raise_error
+      end
+
+      context 'when verify_iss is set to true and no issues given' do
+        it 'does not raise' do
+          expect do
+            JWT.decode(token, data[:secret], true, verify_iss: true, algorithm: 'HS256')
+          end.not_to raise_error
+        end
+      end
+    end
+
+    context 'audience claim' do
+      let(:token) { JWT.encode(payload, data[:secret]) }
+
+      context 'when verify_aud is set to true and no audience given' do
+        it 'does not raise' do
+          expect do
+            JWT.decode(token, data[:secret], true, verify_aud: true, algorithm: 'HS256')
+          end.not_to raise_error
+        end
       end
     end
 


### PR DESCRIPTION
### Description

Fixes regressions introduced in iss and aud claim validation refactorings (#618)

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
