### PR TITLE
Verify JWT header format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Fixes and enhancements:**
 
 - Updated README to correctly document `OpenSSL::HMAC` documentation [#617](https://github.com/jwt/ruby-jwt/pull/617) ([@aedryan](https://github.com/aedryan))
+- Verify JWT header format [#622](https://github.com/jwt/ruby-jwt/pull/622) ([@304](https://github.com/304))
 - Your contribution here
 
 ## [v2.9.1](https://github.com/jwt/ruby-jwt/tree/v2.9.1) (2024-09-23)

--- a/lib/jwt/decode.rb
+++ b/lib/jwt/decode.rb
@@ -49,6 +49,7 @@ module JWT
 
     def verify_algo
       raise JWT::IncorrectAlgorithm, 'An algorithm must be specified' if allowed_algorithms.empty?
+      raise JWT::DecodeError, 'Token header not a JSON object' unless header.is_a?(Hash)
       raise JWT::IncorrectAlgorithm, 'Token is missing alg header' unless alg_in_header
       raise JWT::IncorrectAlgorithm, 'Expected a different algorithm' if allowed_and_valid_algorithms.empty?
     end

--- a/spec/jwt/jwt_spec.rb
+++ b/spec/jwt/jwt_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe JWT do
     data = {
       :empty_token => 'e30K.e30K.e30K',
       :empty_token_2_segment => 'e30K.e30K.',
+      :invalid_header_token => 'W10.e30K.e30K',
       :secret => 'My$ecretK3y',
       :rsa_private => test_pkey('rsa-2048-private.pem'),
       :rsa_public => test_pkey('rsa-2048-public.pem'),
@@ -518,6 +519,14 @@ RSpec.describe JWT do
           expect do
             JWT.decode data[:empty_token]
           end.to raise_error JWT::IncorrectAlgorithm
+        end
+
+        context 'invalid header format' do
+          it 'should raise JWT::DecodeError' do
+            expect do
+              JWT.decode data[:invalid_header_token]
+            end.to raise_error JWT::DecodeError
+          end
         end
 
         context '2-segment token' do


### PR DESCRIPTION
### Description

JWT header is expected to be a hash. However, it's possible to generate a token that defines header as an Array `[]`. This case is not handled by the application and leads to `TypeError: no implicit conversion of String into Integer`.

**Solution**

Add a verification for an header type before accessing hash elements.

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
