### PR TITLE
Do not warn about deprecations yet

### DIFF
--- a/lib/jwt/claims.rb
+++ b/lib/jwt/claims.rb
@@ -34,7 +34,6 @@ module JWT
     class << self
       # @deprecated Use {verify_payload!} instead. Will be removed in the next major version of ruby-jwt.
       def verify!(payload, options)
-        Deprecations.warning('The ::JWT::Claims.verify! method is deprecated will be removed in the next major version of ruby-jwt')
         DecodeVerifier.verify!(payload, options)
       end
 

--- a/lib/jwt/claims/numeric.rb
+++ b/lib/jwt/claims/numeric.rb
@@ -22,7 +22,6 @@ module JWT
       def self.new(*args)
         return super if args.empty?
 
-        Deprecations.warning('Calling ::JWT::Claims::Numeric.new with the payload will be removed in the next major version of ruby-jwt')
         Compat.new(*args)
       end
 
@@ -31,7 +30,6 @@ module JWT
       end
 
       def self.verify!(payload:, **_args)
-        Deprecations.warning('Calling ::JWT::Claims::Numeric.verify! with the payload will be removed in the next major version of ruby-jwt')
         JWT::Claims.verify_payload!(payload, :numeric)
       end
 

--- a/lib/jwt/claims_validator.rb
+++ b/lib/jwt/claims_validator.rb
@@ -5,7 +5,6 @@ require_relative 'error'
 module JWT
   class ClaimsValidator
     def initialize(payload)
-      Deprecations.warning('The ::JWT::ClaimsValidator class is deprecated and will be removed in the next major version of ruby-jwt')
       @payload = payload
     end
 

--- a/lib/jwt/jwa.rb
+++ b/lib/jwt/jwa.rb
@@ -43,7 +43,6 @@ module JWT
       end
 
       def create(algorithm)
-        Deprecations.warning('The ::JWT::JWA.create method is deprecated and will be removed in the next major version of ruby-jwt.')
         resolve(algorithm)
       end
     end

--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -15,13 +15,11 @@ module JWT
       end
 
       def verify_claims(payload, options)
-        Deprecations.warning('The ::JWT::Verify.verify_claims method is deprecated and will be removed in the next major version of ruby-jwt')
         ::JWT::Claims.verify!(payload, options)
       end
     end
 
     def initialize(payload, options)
-      Deprecations.warning('The ::JWT::Verify class is deprecated and will be removed in the next major version of ruby-jwt')
       @payload = payload
       @options = DEFAULTS.merge(options)
     end


### PR DESCRIPTION
### Description

Do not become spammy with deprecation warnings in 2.9.x just yet. 

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
