### PR TITLE
Return truthy value on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Notable changes in the upcoming **version 3.0**:
 
 **Fixes and enhancements:**
 
+- Return truthy value for `::JWT::ClaimsValidator#validate!` and `::JWT::Verify.verify_claims` [#628](https://github.com/jwt/ruby-jwt/pull/628) ([@anakinj](https://github.com/anakinj))
 - Your contribution here
 
 ## [v2.9.2](https://github.com/jwt/ruby-jwt/tree/v2.9.2) (2024-10-03)

--- a/lib/jwt/claims_validator.rb
+++ b/lib/jwt/claims_validator.rb
@@ -10,6 +10,7 @@ module JWT
 
     def validate!
       Claims.verify_payload!(@payload, :numeric)
+      true
     end
   end
 end

--- a/lib/jwt/verify.rb
+++ b/lib/jwt/verify.rb
@@ -16,6 +16,7 @@ module JWT
 
       def verify_claims(payload, options)
         ::JWT::Claims.verify!(payload, options)
+        true
       end
     end
 

--- a/spec/jwt/claims_validator_spec.rb
+++ b/spec/jwt/claims_validator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe JWT::ClaimsValidator do
       context "when #{claim} payload is an integer" do
         let(:claims) { { claim => 12_345 } }
 
+        it { is_expected.to be_truthy }
         it 'does not raise error' do
           expect { subject }.not_to raise_error
         end

--- a/spec/jwt/verify_spec.rb
+++ b/spec/jwt/verify_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe JWT::Verify do
     %w[verify_aud verify_expiration verify_iat verify_iss verify_jti verify_not_before verify_sub].each do |method|
       let(:payload) { base_payload.merge(fail_verifications_payload) }
       it "must skip verification when #{method} option is set to false" do
-        described_class.verify_claims(payload, options.merge(method => false))
+        expect(described_class.verify_claims(payload, options.merge(method => false))).to be_truthy
       end
 
       it "must raise error when #{method} option is set to true" do


### PR DESCRIPTION
### Description

Still one regression in the old methods.

They were returning truthy values so chains like this would stop working:
```
::JWT::Verify.verify_claims(payload, options) && validate_more(payload)
```

This change addresses that by returning `true`.

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
