### PR TITLE
Detached payload support for token object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **Features:**
 
 - JWT::Token and JWT::EncodedToken for signing and verifying tokens [#621](https://github.com/jwt/ruby-jwt/pull/621) ([@anakinj](https://github.com/anakinj))
+- Detached payload support for JWT::Token and JWT::EncodedToken [#630](https://github.com/jwt/ruby-jwt/pull/630) ([@anakinj](https://github.com/anakinj))
 - Your contribution here
 
 **Fixes and enhancements:**

--- a/lib/jwt/encoded_token.rb
+++ b/lib/jwt/encoded_token.rb
@@ -27,7 +27,6 @@ module JWT
 
       @jwt = jwt
       @encoded_header, @encoded_payload, @encoded_signature = jwt.split('.')
-      @signing_input = [encoded_header, encoded_payload].join('.')
     end
 
     # Returns the decoded signature of the JWT token.
@@ -58,18 +57,21 @@ module JWT
     #
     # @return [Hash] the payload.
     def payload
-      @payload ||= parse_and_decode(encoded_payload)
+      @payload ||= encoded_payload == '' ? raise(JWT::DecodeError, 'Encoded payload is empty') : parse_and_decode(encoded_payload)
     end
 
-    # Returns the encoded payload of the JWT token.
+    # Sets or returns the encoded payload of the JWT token.
     #
     # @return [String] the encoded payload.
-    attr_reader :encoded_payload
+    # @param value [String] the encoded payload to set.
+    attr_accessor :encoded_payload
 
     # Returns the signing input of the JWT token.
     #
     # @return [String] the signing input.
-    attr_reader :signing_input
+    def signing_input
+      [encoded_header, encoded_payload].join('.')
+    end
 
     # Verifies the signature of the JWT token.
     #

--- a/lib/jwt/token.rb
+++ b/lib/jwt/token.rb
@@ -76,7 +76,15 @@ module JWT
     # @return [String] the JWT token as a string.
     # @raise [JWT::EncodeError] if the token is not signed or other encoding issues
     def jwt
-      @jwt ||= (@signature && [encoded_header, encoded_payload, encoded_signature].join('.')) || raise(::JWT::EncodeError, 'Token is not signed')
+      @jwt ||= (@signature && [encoded_header, @detached_payload ? '' : encoded_payload, encoded_signature].join('.')) || raise(::JWT::EncodeError, 'Token is not signed')
+    end
+
+    # Detaches the payload according to https://datatracker.ietf.org/doc/html/rfc7515#appendix-F
+    #
+    def detach_payload!
+      @detached_payload = true
+
+      nil
     end
 
     # Signs the JWT token.
@@ -92,6 +100,8 @@ module JWT
         header.merge!(algo.header)
         @signature = algo.sign(data: signing_input, signing_key: key)
       end
+
+      nil
     end
 
     # Returns the JWT token as a string.

--- a/spec/jwt/token_spec.rb
+++ b/spec/jwt/token_spec.rb
@@ -42,4 +42,14 @@ RSpec.describe JWT::Token do
       end
     end
   end
+
+  describe '#detach_payload!' do
+    context 'before token is signed' do
+      it 'detaches the payload' do
+        token.detach_payload!
+        token.sign!(algorithm: 'HS256', key: 'secret')
+        expect(token.jwt).to eq('eyJhbGciOiJIUzI1NiJ9..UEhDY1Qlj29ammxuVRA_-gBah4qTy5FngIWg0yEAlC0')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description

Detatched payload support for Token objects.

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
