### PR TITLE
Do not decode payload when b64 header is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - JWT::Token and JWT::EncodedToken for signing and verifying tokens [#621](https://github.com/jwt/ruby-jwt/pull/621) ([@anakinj](https://github.com/anakinj))
 - Detached payload support for JWT::Token and JWT::EncodedToken [#630](https://github.com/jwt/ruby-jwt/pull/630) ([@anakinj](https://github.com/anakinj))
+- Skip decoding payload if b64 header is present and false [#631](https://github.com/jwt/ruby-jwt/pull/631) ([@anakinj](https://github.com/anakinj))
 - Your contribution here
 
 **Fixes and enhancements:**

--- a/lib/jwt/claims.rb
+++ b/lib/jwt/claims.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative 'claims/audience'
+require_relative 'claims/crit'
+require_relative 'claims/decode_verifier'
 require_relative 'claims/expiration'
 require_relative 'claims/issued_at'
 require_relative 'claims/issuer'
@@ -9,9 +11,8 @@ require_relative 'claims/not_before'
 require_relative 'claims/numeric'
 require_relative 'claims/required'
 require_relative 'claims/subject'
-require_relative 'claims/decode_verifier'
-require_relative 'claims/verifier'
 require_relative 'claims/verification_methods'
+require_relative 'claims/verifier'
 
 module JWT
   # JWT Claim verifications
@@ -27,7 +28,6 @@ module JWT
   # sub
   # required
   # numeric
-  #
   module Claims
     # Represents a claim verification error
     Error = Struct.new(:message, keyword_init: true)

--- a/lib/jwt/claims/crit.rb
+++ b/lib/jwt/claims/crit.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module JWT
+  module Claims
+    # Responsible of validation the crit header
+    class Crit
+      # Initializes a new Crit instance.
+      #
+      # @param expected_crits [String] the expected crit header values for the JWT token.
+      def initialize(expected_crits:)
+        @expected_crits = Array(expected_crits)
+      end
+
+      # Verifies the critical claim ('crit') in the JWT token header.
+      #
+      # @param context [Object] the context containing the JWT payload and header.
+      # @param _args [Hash] additional arguments (not used).
+      # @raise [JWT::InvalidCritError] if the crit claim is invalid.
+      # @return [nil]
+      def verify!(context:, **_args)
+        raise(JWT::InvalidCritError, 'Crit header missing') unless context.header['crit']
+        raise(JWT::InvalidCritError, 'Crit header should be an array') unless context.header['crit'].is_a?(Array)
+
+        missing = (expected_crits - context.header['crit'])
+        raise(JWT::InvalidCritError, "Crit header missing expected values: #{missing.join(', ')}") if missing.any?
+
+        nil
+      end
+
+      private
+
+      attr_reader :expected_crits
+    end
+  end
+end

--- a/lib/jwt/claims/verifier.rb
+++ b/lib/jwt/claims/verifier.rb
@@ -12,7 +12,7 @@ module JWT
         jti: ->(options) { Claims::JwtId.new(validator: options[:jti]) },
         aud: ->(options) { Claims::Audience.new(expected_audience: options[:aud]) },
         sub: ->(options) { Claims::Subject.new(expected_subject: options[:sub]) },
-
+        crit: ->(options) { Claims::Crit.new(expected_crits: options[:crit]) },
         required: ->(options) { Claims::Required.new(required_claims: options[:required]) },
         numeric: ->(*)        { Claims::Numeric.new }
       }.freeze

--- a/lib/jwt/error.rb
+++ b/lib/jwt/error.rb
@@ -37,6 +37,9 @@ module JWT
   # The InvalidSubError class is raised when the JWT subject (sub) claim is invalid.
   class InvalidSubError < DecodeError; end
 
+  # The InvalidCritError class is raised when the JWT crit header is invalid.
+  class InvalidCritError < DecodeError; end
+
   # The InvalidJtiError class is raised when the JWT ID (jti) claim is invalid.
   class InvalidJtiError < DecodeError; end
 

--- a/spec/jwt/claims/crit_spec.rb
+++ b/spec/jwt/claims/crit_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe JWT::Claims::Crit do
+  subject(:verify!) { described_class.new(expected_crits: expected_crits).verify!(context: SpecSupport::Token.new(header: header)) }
+  let(:expected_crits) { [] }
+  let(:header) { {} }
+
+  context 'when header is missing' do
+    it 'raises JWT::InvalidCritError' do
+      expect { verify! }.to raise_error(JWT::InvalidCritError, 'Crit header missing')
+    end
+  end
+
+  context 'when header is not an array' do
+    let(:header) { { 'crit' => 'not_an_array' } }
+
+    it 'raises JWT::InvalidCritError' do
+      expect { verify! }.to raise_error(JWT::InvalidCritError, 'Crit header should be an array')
+    end
+  end
+
+  context 'when header is an array and not containing the expected value' do
+    let(:header) { { 'crit' => %w[crit1] } }
+    let(:expected_crits) { %w[crit2] }
+    it 'raises an InvalidCritError' do
+      expect { verify! }.to raise_error(JWT::InvalidCritError, 'Crit header missing expected values: crit2')
+    end
+  end
+
+  context 'when header is an array containing exactly the expected values' do
+    let(:header) { { 'crit' => %w[crit1 crit2] } }
+    let(:expected_crits) { %w[crit1 crit2] }
+    it 'does not raise an error' do
+      expect(verify!).to eq(nil)
+    end
+  end
+
+  context 'when header is an array containing at least the expected values' do
+    let(:header) { { 'crit' => %w[crit1 crit2 crit3] } }
+    let(:expected_crits) { %w[crit1 crit2] }
+    it 'does not raise an error' do
+      expect(verify!).to eq(nil)
+    end
+  end
+end

--- a/spec/spec_support/token.rb
+++ b/spec/spec_support/token.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SpecSupport
-  Token = Struct.new(:payload, keyword_init: true)
+  Token = Struct.new(:payload, :header, keyword_init: true)
 end


### PR DESCRIPTION
### Description

Skip decoding if the b64 header is set to false

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [ ] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
