### PR TITLE
Use correct methods when raising error during signing/verification with EdDSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Deprecation warnings for deprecated methods and classes [#629](https://github.com/jwt/ruby-jwt/pull/629) ([@anakinj](https://github.com/anakinj))
 - Improved documentation for public apis [#629](https://github.com/jwt/ruby-jwt/pull/629) ([@anakinj](https://github.com/anakinj))
+- Use correct methods when raising error during signing/verification with EdDSA [#633](https://github.com/jwt/ruby-jwt/pull/633)
 - Your contribution here
 
 ## [v2.9.3](https://github.com/jwt/ruby-jwt/tree/v2.9.3) (2024-10-03)

--- a/lib/jwt/jwa/eddsa.rb
+++ b/lib/jwt/jwa/eddsa.rb
@@ -11,7 +11,7 @@ module JWT
 
       def sign(data:, signing_key:)
         unless signing_key.is_a?(RbNaCl::Signatures::Ed25519::SigningKey)
-          raise_encode_error!("Key given is a #{signing_key.class} but has to be an RbNaCl::Signatures::Ed25519::SigningKey")
+          raise_sign_error!("Key given is a #{signing_key.class} but has to be an RbNaCl::Signatures::Ed25519::SigningKey")
         end
 
         signing_key.sign(data)
@@ -19,7 +19,7 @@ module JWT
 
       def verify(data:, signature:, verification_key:)
         unless verification_key.is_a?(RbNaCl::Signatures::Ed25519::VerifyKey)
-          raise_decode_error!("key given is a #{verification_key.class} but has to be a RbNaCl::Signatures::Ed25519::VerifyKey")
+          raise_verify_error!("key given is a #{verification_key.class} but has to be a RbNaCl::Signatures::Ed25519::VerifyKey")
         end
 
         verification_key.verify(signature, data)

--- a/spec/jwt/jwa/eddsa_spec.rb
+++ b/spec/jwt/jwa/eddsa_spec.rb
@@ -13,4 +13,20 @@ RSpec.describe 'JWT::JWA::Eddsa' do
       expect(JWT::JWA::Eddsa.verify('RS256', key.verify_key, 'data', signature)).to be(true)
     end
   end
+
+  context 'when when signing with invalid RbNaCl::Signatures::Ed25519::SigningKey' do
+    it 'raises an error' do
+      expect do
+        JWT::JWA::Eddsa.sign('RS256', 'data', 'key')
+      end.to raise_error(JWT::EncodeError, 'Key given is a String but has to be an RbNaCl::Signatures::Ed25519::SigningKey')
+    end
+  end
+
+  context 'when when verifying with invalid RbNaCl::Signatures::Ed25519::VerifyKey' do
+    it 'raises an error' do
+      expect do
+        JWT::JWA::Eddsa.verify('RS256', 'key', 'data', 'signature')
+      end.to raise_error(JWT::DecodeError, 'key given is a String but has to be a RbNaCl::Signatures::Ed25519::VerifyKey')
+    end
+  end
 end


### PR DESCRIPTION
### Description

This Pull Request changes/fixes this error when the key for EdDSA is invalid

```
NoMethodError:
  undefined method `raise_encode_error!' for an instance of JWT::JWA::Eddsa
```

This method is renamed to `raise_sign_error!`. This PR updates `raise_decode_error!` to `raise_verify_error!`, too.
### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
