### PR TITLE
Handle empty string as token value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Deprecation warnings for deprecated methods and classes [#629](https://github.com/jwt/ruby-jwt/pull/629) ([@anakinj](https://github.com/anakinj))
 - Improved documentation for public apis [#629](https://github.com/jwt/ruby-jwt/pull/629) ([@anakinj](https://github.com/anakinj))
 - Use correct methods when raising error during signing/verification with EdDSA [#633](https://github.com/jwt/ruby-jwt/pull/633)
+- Fix JWT::EncodedToken behavior with empty string as token [#640](https://github.com/jwt/ruby-jwt/pull/640) ([@ragalie](https://github.com/ragalie))
 - Your contribution here
 
 ## [v2.9.3](https://github.com/jwt/ruby-jwt/tree/v2.9.3) (2024-10-03)

--- a/lib/jwt/encoded_token.rb
+++ b/lib/jwt/encoded_token.rb
@@ -124,7 +124,7 @@ module JWT
     end
 
     def parse_and_decode(segment)
-      parse(::JWT::Base64.url_decode(segment))
+      parse(::JWT::Base64.url_decode(segment || ''))
     end
 
     def parse_unencoded(segment)

--- a/spec/jwt/encoded_token_spec.rb
+++ b/spec/jwt/encoded_token_spec.rb
@@ -40,10 +40,26 @@ RSpec.describe JWT::EncodedToken do
         expect(token.payload).to eq({ 'foo' => 'bar' })
       end
     end
+
+    context 'when token is the empty string' do
+      let(:encoded_token) { '' }
+
+      it 'raises decode error' do
+        expect { token.payload }.to raise_error(JWT::DecodeError, 'Invalid segment encoding')
+      end
+    end
   end
 
   describe '#header' do
     it { expect(token.header).to eq({ 'alg' => 'HS256' }) }
+
+    context 'when token is the empty string' do
+      let(:encoded_token) { '' }
+
+      it 'raises decode error' do
+        expect { token.header }.to raise_error(JWT::DecodeError, 'Invalid segment encoding')
+      end
+    end
   end
 
   describe '#signature' do


### PR DESCRIPTION
### Description

If the token is the empty string we try to pass `nil` to `Base64.url_decode`, which always expects a string.

This ensures we always pass a string to avoid an unexpected error.

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
