### PR TITLE
Deprecation warnings for Rbnacl backed functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Improved documentation for public apis [#629](https://github.com/jwt/ruby-jwt/pull/629) ([@anakinj](https://github.com/anakinj))
 - Use correct methods when raising error during signing/verification with EdDSA [#633](https://github.com/jwt/ruby-jwt/pull/633)
 - Fix JWT::EncodedToken behavior with empty string as token [#640](https://github.com/jwt/ruby-jwt/pull/640) ([@ragalie](https://github.com/ragalie))
+- Deprecation warnings for rbnacl backed functionality [#641](https://github.com/jwt/ruby-jwt/pull/641) ([@anakinj](https://github.com/anakinj))
 - Your contribution here
 
 ## [v2.9.3](https://github.com/jwt/ruby-jwt/tree/v2.9.3) (2024-10-03)

--- a/lib/jwt/jwa/eddsa.rb
+++ b/lib/jwt/jwa/eddsa.rb
@@ -13,11 +13,15 @@ module JWT
       def sign(data:, signing_key:)
         raise_sign_error!("Key given is a #{signing_key.class} but has to be an RbNaCl::Signatures::Ed25519::SigningKey") unless signing_key.is_a?(RbNaCl::Signatures::Ed25519::SigningKey)
 
+        Deprecations.warning('Using Ed25519 keys is deprecated and will be removed in a future version of ruby-jwt. Please use the ruby-eddsa gem instead.')
+
         signing_key.sign(data)
       end
 
       def verify(data:, signature:, verification_key:)
         raise_verify_error!("key given is a #{verification_key.class} but has to be a RbNaCl::Signatures::Ed25519::VerifyKey") unless verification_key.is_a?(RbNaCl::Signatures::Ed25519::VerifyKey)
+
+        Deprecations.warning('Using Ed25519 keys is deprecated and will be removed in a future version of ruby-jwt. Please use the ruby-eddsa gem instead.')
 
         verification_key.verify(signature, data)
       rescue RbNaCl::CryptoError

--- a/lib/jwt/jwk/okp_rbnacl.rb
+++ b/lib/jwt/jwk/okp_rbnacl.rb
@@ -11,7 +11,7 @@ module JWT
 
       def initialize(key, params = nil, options = {})
         params ||= {}
-
+        Deprecations.warning('Using the OKP JWK for Ed25519 keys is deprecated and will be removed in a future version of ruby-jwt. Please use the ruby-eddsa gem instead.')
         # For backwards compatibility when kid was a String
         params = { kid: params } if params.is_a?(String)
 


### PR DESCRIPTION
### Description

Ed25519 algo is moved outside of this gem for clearer dependency handling. Prepping to remove the logic. 

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
