### PR TITLE
Make version constants public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Changelog
 
-## [v3.0.0](https://github.com/jwt/ruby-jwt/tree/v3.0.0) (NEXT)
-
-**Features:**
-
-- Your contribution here
+## [v2.10.1](https://github.com/jwt/ruby-jwt/tree/v2.10.1) (2024-12-26)
 
 **Fixes and enhancements:**
 
-- Your contribution here
+- Make version constants public again [#646](https://github.com/jwt/ruby-jwt/pull/646) ([@anakinj]
 
 ## [v2.10.0](https://github.com/jwt/ruby-jwt/tree/v2.10.0) (2024-12-25)
 

--- a/lib/jwt/version.rb
+++ b/lib/jwt/version.rb
@@ -14,14 +14,12 @@ module JWT
 
   # @api private
   module VERSION
-    MAJOR = 3
-    MINOR = 0
-    TINY  = 0
+    MAJOR = 2
+    MINOR = 10
+    TINY  = 1
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
-
-    private_constant(:MAJOR, :MINOR, :TINY, :PRE)
   end
 
   # Checks if the OpenSSL version is 3 or greater.


### PR DESCRIPTION
### Description

Making the constants private is a breaking change. Yet another change for 3.x

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
