### PR TITLE
Drop loose base64 decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Drop support for the HS512256 algorithm [#650](https://github.com/jwt/ruby-jwt/pull/650) ([@anakinj](https://github.com/anakinj))
 - Remove deprecated claim verification methods [#654](https://github.com/jwt/ruby-jwt/pull/654) ([@anakinj](https://github.com/anakinj))
 - Remove dependency to rbnacl [#655](https://github.com/jwt/ruby-jwt/pull/655) ([@anakinj](https://github.com/anakinj))
+- Support only stricter base64 decoding (RFC 4648) [#658](https://github.com/jwt/ruby-jwt/pull/658) ([@anakinj](https://github.com/anakinj))
 
 Take a look at the [upgrade guide](UPGRADING.md) for more details.
 

--- a/lib/jwt/base64.rb
+++ b/lib/jwt/base64.rb
@@ -14,22 +14,13 @@ module JWT
       end
 
       # Decode a string with URL-safe Base64 complying with RFC 4648.
-      # Deprecated support for RFC 2045 remains for now. ("All line breaks or other characters not found in Table 1 must be ignored by decoding software")
       # @api private
       def url_decode(str)
         ::Base64.urlsafe_decode64(str)
       rescue ArgumentError => e
         raise unless e.message == 'invalid base64'
-        raise Base64DecodeError, 'Invalid base64 encoding' if JWT.configuration.strict_base64_decoding
 
-        loose_urlsafe_decode64(str).tap do
-          Deprecations.warning('Invalid base64 input detected, could be because of invalid padding, trailing whitespaces or newline chars. Graceful handling of invalid input will be dropped in the next major version of ruby-jwt', only_if_valid: true)
-        end
-      end
-
-      def loose_urlsafe_decode64(str)
-        str += '=' * (4 - str.length.modulo(4))
-        ::Base64.decode64(str.tr('-_', '+/'))
+        raise Base64DecodeError, 'Invalid base64 encoding'
       end
     end
   end


### PR DESCRIPTION
### Description

Support only stricter base64 decoding

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [ ] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
