### PR TITLE
Require RSA keys of minimum 2048 bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 - Remove deprecated claim verification methods [#654](https://github.com/jwt/ruby-jwt/pull/654) ([@anakinj](https://github.com/anakinj))
 - Remove dependency to rbnacl [#655](https://github.com/jwt/ruby-jwt/pull/655) ([@anakinj](https://github.com/anakinj))
 - Support only stricter base64 decoding (RFC 4648) [#658](https://github.com/jwt/ruby-jwt/pull/658) ([@anakinj](https://github.com/anakinj))
-- Custom algorithms are required to include `JWT::JWA::SigningAlgorithm` [#660](https://github.com/jwt/ruby-jwt/pull/560) ([@anakinj](https://github.com/anakinj))
+- Custom algorithms are required to include `JWT::JWA::SigningAlgorithm` [#660](https://github.com/jwt/ruby-jwt/pull/660) ([@anakinj](https://github.com/anakinj))
+- Require RSA keys to be at least 2048 bits [#661](https://github.com/jwt/ruby-jwt/pull/661) ([@anakinj](https://github.com/anakinj))
 
 Take a look at the [upgrade guide](UPGRADING.md) for more details.
 

--- a/lib/jwt/jwa/ps.rb
+++ b/lib/jwt/jwa/ps.rb
@@ -13,6 +13,7 @@ module JWT
 
       def sign(data:, signing_key:)
         raise_sign_error!("The given key is a #{signing_key.class}. It has to be an OpenSSL::PKey::RSA instance.") unless signing_key.is_a?(::OpenSSL::PKey::RSA)
+        raise_sign_error!('The key length must be greater than or equal to 2048 bits') if signing_key.n.num_bits < 2048
 
         signing_key.sign_pss(digest_algorithm, data, salt_length: :digest, mgf1_hash: digest_algorithm)
       end

--- a/lib/jwt/jwa/rsa.rb
+++ b/lib/jwt/jwa/rsa.rb
@@ -13,6 +13,7 @@ module JWT
 
       def sign(data:, signing_key:)
         raise_sign_error!("The given key is a #{signing_key.class}. It has to be an OpenSSL::PKey::RSA instance") unless signing_key.is_a?(OpenSSL::PKey::RSA)
+        raise_sign_error!('The key length must be greater than or equal to 2048 bits') if signing_key.n.num_bits < 2048
 
         signing_key.sign(digest, data)
       end

--- a/spec/jwt/jwa/ps_spec.rb
+++ b/spec/jwt/jwa/ps_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe JWT::JWA::Ps do
         end.to raise_error(JWT::EncodeError, /The given key is a String. It has to be an OpenSSL::PKey::RSA instance./)
       end
     end
+
+    context 'with a key length less than 2048 bits' do
+      let(:rsa_key) { OpenSSL::PKey::RSA.generate(1024) }
+
+      it 'raises an error' do
+        expect do
+          ps256_instance.sign(data: data, signing_key: rsa_key)
+        end.to raise_error(JWT::EncodeError, 'The key length must be greater than or equal to 2048 bits')
+      end
+    end
   end
 
   describe '#verify' do

--- a/spec/jwt/jwa/rsa_spec.rb
+++ b/spec/jwt/jwa/rsa_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe JWT::JWA::Rsa do
       end
     end
 
+    context 'with a key length less than 2048 bits' do
+      let(:rsa_key) { OpenSSL::PKey::RSA.generate(1024) }
+
+      it 'raises an error' do
+        expect do
+          rsa_instance.sign(data: data, signing_key: rsa_key)
+        end.to raise_error(JWT::EncodeError, 'The key length must be greater than or equal to 2048 bits')
+      end
+    end
+
     context 'with an invalid key' do
       it 'raises an error' do
         expect do


### PR DESCRIPTION
### Description

The JWA spec states for the RS and PS algos: "A key of size 2048 bits or larger MUST be used with these algorithms"

https://datatracker.ietf.org/doc/html/rfc7518#section-3.3
https://datatracker.ietf.org/doc/html/rfc7518#section-3.5

Fixes #635 

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
