### PR TITLE
Better support for keyfinders and EncodedToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Take a look at the [upgrade guide](UPGRADING.md) for more details.
 **Features:**
 - JWT::EncodedToken#verify! method that bundles signature and claim validation [#647](https://github.com/jwt/ruby-jwt/pull/647) ([@anakinj](https://github.com/anakinj))
 - Do not override the alg header if already given [#659](https://github.com/jwt/ruby-jwt/pull/659) ([@anakinj](https://github.com/anakinj))
+- Make `JWK::KeyFinder` compatible with `JWT::EncodedToken` [#663](https://github.com/jwt/ruby-jwt/pull/663) ([@anakinj](https://github.com/anakinj))
 - Your contribution here
 
 **Fixes and enhancements:**

--- a/lib/jwt/jwk/key_finder.rb
+++ b/lib/jwt/jwk/key_finder.rb
@@ -2,8 +2,13 @@
 
 module JWT
   module JWK
-    # @api private
+    # JSON Web Key keyfinder
+    # To find the key for a given kid
     class KeyFinder
+      # Initializes a new KeyFinder instance.
+      # @param [Hash] options the options to create a KeyFinder with
+      # @option options [Proc, JWT::JWK::Set] :jwks the jwks or a loader proc
+      # @option options [Boolean] :allow_nil_kid whether to allow nil kid
       def initialize(options)
         @allow_nil_kid = options[:allow_nil_kid]
         jwks_or_loader = options[:jwks]
@@ -15,6 +20,8 @@ module JWT
                        end
       end
 
+      # Returns the verification key for the given kid
+      # @param [String] kid the key id
       def key_for(kid)
         raise ::JWT::DecodeError, 'No key id (kid) found from token headers' unless kid || @allow_nil_kid
         raise ::JWT::DecodeError, 'Invalid type for kid header parameter' unless kid.nil? || kid.is_a?(String)
@@ -25,6 +32,12 @@ module JWT
         raise ::JWT::DecodeError, "Could not find public key for kid #{kid}" unless jwk
 
         jwk.verify_key
+      end
+
+      # Returns the key for the given token
+      # @param [JWT::EncodedToken] token the token
+      def call(token)
+        key_for(token.header['kid'])
       end
 
       private

--- a/spec/jwt/encoded_token_spec.rb
+++ b/spec/jwt/encoded_token_spec.rb
@@ -161,6 +161,20 @@ RSpec.describe JWT::EncodedToken do
         expect(token.verify_signature!(algorithm: 'HS256', key: key)).to eq(nil)
       end
     end
+
+    context 'when JWT::KeyFinder is used as a key_finder' do
+      let(:jwk) { JWT::JWK.new(test_pkey('rsa-2048-private.pem')) }
+      let(:encoded_token) do
+        JWT::Token.new(payload: payload, header: { kid: jwk.kid })
+                  .tap { |t| t.sign!(algorithm: 'RS256', key: jwk.signing_key) }
+                  .jwt
+      end
+
+      it 'uses the keys provided by the JWK key finder' do
+        key_finder = JWT::JWK::KeyFinder.new(jwks: JWT::JWK::Set.new(jwk))
+        expect(token.verify_signature!(algorithm: 'RS256', key_finder: key_finder)).to eq(nil)
+      end
+    end
   end
 
   describe '#verify_claims!' do


### PR DESCRIPTION
### Description

- Add #call method to JWK::KeyFinder to be compatible with EncodedToken#verify_signature!
- Document how to use a keyfinder

### Checklist

Before the PR can be merged be sure the following are checked:
* [x] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
