### PR TITLE
Add logger as development dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,10 +72,10 @@ jobs:
         run: bundle exec rspec
 
       - name: Upload test coverage folder for later reporting
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-reports
-          path: ${{github.workspace}}/coverage-*/coverage.json
+          path: ${{github.workspace}}/coverage-*/coverage-${{ matrix.os }}-${{ matrix.ruby }}.json
           retention-days: 1
 
   coverage:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Take a look at the [upgrade guide](UPGRADING.md) for more details.
 **Fixes and enhancements:**
 
 - Ruby 3.4 to CI matrix [#649](https://github.com/jwt/ruby-jwt/pull/649) ([@anakinj](https://github.com/anakinj))
+- Add logger as development dependency [#670](https://github.com/jwt/ruby-jwt/pull/670) ([@hieuk09](https://github.com/hieuk09))
 - Your contribution here
 
 ## [v2.10.1](https://github.com/jwt/ruby-jwt/tree/v2.10.1) (2024-12-26)

--- a/ruby-jwt.gemspec
+++ b/ruby-jwt.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'logger'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'


### PR DESCRIPTION
### Description

I see that the test fails when running versus Ruby head. It seems like latest ruby removes `logger` from the bundled gems

<img width="1130" alt="Screenshot 2025-04-05 at 6 16 40 AM" src="https://github.com/user-attachments/assets/5556159c-1736-426a-9b3c-3947734b6bad" />

### Checklist

Before the PR can be merged be sure the following are checked:
* [ ] There are tests for the fix or feature added/changed
* [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
