### PR TITLE
Re-enable Truffleruby on the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,11 +47,10 @@ jobs:
             ruby: "2.5"
             gemfile: gemfiles/openssl.gemfile
             experimental: false
-          # Disable temporarily due to `ArgumentError: circular causes` error
-          # - os: ubuntu-latest
-          #   ruby: "truffleruby-head"
-          #   gemfile: "gemfiles/standalone.gemfile"
-          #   experimental: true
+          - os: ubuntu-latest
+            ruby: "truffleruby-head"
+            gemfile: "gemfiles/standalone.gemfile"
+            experimental: true
           - os: ubuntu-latest
             ruby: head
             gemfile: gemfiles/standalone.gemfile


### PR DESCRIPTION
### Description

Trying to get the Truffleruby CI step enabled again.

### Checklist

Before the PR can be merged be sure the following are checked:

- [x] There are tests for the fix or feature added/changed
- [ ] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
