### PR TITLE
Fix signing with EC JWK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Fixes and enhancements:**
 
+- Fix signing with a EC JWK [#699](https://github.com/jwt/ruby-jwt/pull/699) ([@anakinj](https://github.com/anakinj))
 - Your contribution here
 
 ## [v3.1.1](https://github.com/jwt/ruby-jwt/tree/v3.1.1) (2025-06-24)

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ jwk = JWT::JWK.import(JSON.parse(jwk_json))
 
 token = JWT::Token.new(payload: payload, header: header)
 
-token.sign!(key: jwk)
+token.sign!(key: jwk, algorithm: 'HS256')
 
 encoded_token = JWT::EncodedToken.new(token.jwt)
 encoded_token.verify!(signature: { algorithm: ["HS256", "HS512"], key: jwk})

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -71,14 +71,14 @@ module JWT
         super
       end
 
-      private
-
       def jwa
         return super if self[:alg]
 
         curve_name = self.class.to_openssl_curve(self[:crv])
         JWA.resolve(JWA::Ecdsa.curve_by_name(curve_name)[:algorithm])
       end
+
+      private
 
       def ec_key
         @ec_key ||= create_ec_key(self[:crv], self[:x], self[:y], self[:d])

--- a/spec/jwt/encoded_token_spec.rb
+++ b/spec/jwt/encoded_token_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe JWT::EncodedToken do
       end
     end
 
-    context 'when JWK is given as a key' do
+    context 'when RSA JWK is given as a key' do
       let(:jwk) { JWT::JWK.new(test_pkey('rsa-2048-private.pem'), alg: 'RS256') }
       let(:encoded_token) do
         JWT::Token.new(payload: payload)

--- a/spec/jwt/token_spec.rb
+++ b/spec/jwt/token_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe JWT::Token do
       end
     end
 
-    context 'when JWK is given as key' do
+    context 'when RSA JWK is given as key' do
       let(:jwk) { JWT::JWK::RSA.new(OpenSSL::PKey::RSA.new(2048), alg: 'RS256') }
 
       it 'signs the token' do
@@ -51,6 +51,16 @@ RSpec.describe JWT::Token do
       it 'raises an error' do
         expect { token.sign!(key: 'secret') }.to raise_error(ArgumentError, /missing keyword/)
       end
+    end
+  end
+
+  context 'when EC JWK is given as key' do
+    let(:jwk) { JWT::JWK::EC.new(test_pkey('ec384-private.pem')) }
+
+    it 'signs the token' do
+      token.sign!(key: jwk, algorithm: [])
+
+      expect(JWT::EncodedToken.new(token.jwt).valid_signature?(algorithm: [], key: jwk)).to be(true)
     end
   end
 


### PR DESCRIPTION
### Description

The `jwa` method was private for the EC JWK, this made it impossible to use the JWK to sign tokens.

### Checklist

Before the PR can be merged be sure the following are checked:

- [x] There are tests for the fix or feature added/changed
- [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
