### PR TITLE
Add enforce_hmac_key_length configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Features:**
 
+- Add `enforce_hmac_key_length` configuration option [#716](https://github.com/jwt/ruby-jwt/pull/716) - ([@304](https://github.com/304))
 - Your contribution here
 
 **Fixes and enhancements:**

--- a/lib/jwt/configuration/decode_configuration.rb
+++ b/lib/jwt/configuration/decode_configuration.rb
@@ -24,6 +24,8 @@ module JWT
       #   @return [Array<String>] the list of acceptable algorithms.
       # @!attribute [rw] required_claims
       #   @return [Array<String>] the list of required claims.
+      # @!attribute [rw] enforce_hmac_key_length
+      #   @return [Boolean] whether to enforce minimum HMAC key lengths. false disables validation (default).
 
       attr_accessor :verify_expiration,
                     :verify_not_before,
@@ -34,7 +36,8 @@ module JWT
                     :verify_sub,
                     :leeway,
                     :algorithms,
-                    :required_claims
+                    :required_claims,
+                    :enforce_hmac_key_length
 
       # Initializes a new DecodeConfiguration instance with default settings.
       def initialize
@@ -48,6 +51,7 @@ module JWT
         @leeway = 0
         @algorithms = ['HS256']
         @required_claims = []
+        @enforce_hmac_key_length = false
       end
 
       # @api private
@@ -62,7 +66,8 @@ module JWT
           verify_sub: verify_sub,
           leeway: leeway,
           algorithms: algorithms,
-          required_claims: required_claims
+          required_claims: required_claims,
+          enforce_hmac_key_length: enforce_hmac_key_length
         }
       end
     end


### PR DESCRIPTION
### Description

Add `enforce_hmac_key_length` configuration option to enforce minimum key lengths for HMAC algorithms. This is a security hardening measure that helps prevent brute-force attacks on weak keys.

Recommended minimum key lengths per RFC 7518 Section 3.2:
- HS256: 256 bits (32 bytes)
- HS384: 384 bits (48 bytes)
- HS512: 512 bits (64 bytes)

See: https://www.rfc-editor.org/rfc/rfc7518.html#section-3.2

Usage:
```ruby
  JWT.configuration.decode.enforce_hmac_key_length = true
```

For backward compatibility, it's disabled by default (false). But it would be nice to enforce it in a future major version like it's done for RSA key validation (minimum 2048 bits). For now, users must explicitly opt-in.

### Checklist

Before the PR can be merged be sure the following are checked:

- [x] There are tests for the fix or feature added/changed
- [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
