### PR TITLE
Ignore unkown algorithm jwks per RFC7517

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v3.2.1](https://github.com/jwt/ruby-jwt/tree/v3.2.1) (NEXT)
+
+[Full Changelog](https://github.com/jwt/ruby-jwt/compare/v3.2.0...v3.2.1)
+
+**Features:**
+
+- Your contribution here
+
+**Fixes and enhancements:**
+
+- Fix rejection of unknown algorithms from JWKs for RFC compliance and pquip [#728](https://github.com/jwt/ruby-jwt/pull/728)
+
 ## [v3.2.0](https://github.com/jwt/ruby-jwt/tree/v3.2.0) (2026-05-13)
 
 [Full Changelog](https://github.com/jwt/ruby-jwt/compare/v3.1.2...v3.2.0)

--- a/lib/jwt/error.rb
+++ b/lib/jwt/error.rb
@@ -51,4 +51,7 @@ module JWT
 
   # The JWKError class is raised when there is an error with the JSON Web Key (JWK).
   class JWKError < DecodeError; end
+
+  # Raised when a JWK uses a key type (kty) that this library does not support.
+  class UnsupportedKeyType < JWKError; end
 end

--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -13,7 +13,7 @@ module JWT
           raise JWT::JWKError, 'Key type (kty) not provided' unless jwk_kty
 
           return mappings.fetch(jwk_kty.to_s) do |kty|
-            raise JWT::JWKError, "Key type #{kty} not supported"
+            raise JWT::UnsupportedKeyType, "Key type #{kty} not supported"
           end.new(key, params, options)
         end
 

--- a/lib/jwt/jwk/set.rb
+++ b/lib/jwt/jwk/set.rb
@@ -22,7 +22,11 @@ module JWT
                   [jwks]
                 when Hash
                   jwks = jwks.transform_keys(&:to_sym)
-                  [*jwks[:keys]].map { |k| JWT::JWK.new(k, nil, options) }
+                  [*jwks[:keys]].each_with_object([]) do |k, arr|
+                    arr << JWT::JWK.new(k, nil, options)
+                  rescue JWT::UnsupportedKeyType
+                    nil
+                  end
                 when Array
                   jwks.map { |k| JWT::JWK.new(k, nil, options) }
                 else

--- a/lib/jwt/version.rb
+++ b/lib/jwt/version.rb
@@ -16,7 +16,7 @@ module JWT
   module VERSION
     MAJOR = 3
     MINOR = 2
-    TINY  = 0
+    TINY  = 1
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/spec/jwt/jwk/set_spec.rb
+++ b/spec/jwt/jwk/set_spec.rb
@@ -36,6 +36,38 @@ RSpec.describe JWT::JWK::Set do
       end
     end
 
+    it 'ignores keys with unsupported kty values (RFC 7517 §5), required for hybrid PQC' do
+      jwks = {
+        keys: [
+          { kty: 'unknown', alg: 'unknown-alg', kid: 'unknown' },
+          { kty: 'oct', k: Base64.strict_encode64('testkey') }
+        ]
+      }
+      set = described_class.new(jwks)
+      expect(set.size).to eql(1)
+      expect(set.keys[0][:kty]).to eql('oct')
+    end
+
+    it 'returns an empty set when all keys have unsupported kty values' do
+      jwks = {
+        keys: [
+          { kty: 'unknown', alg: 'unknown-alg', kid: 'unknown-1' },
+          { kty: 'future', alg: 'future-alg', kid: 'future-1' }
+        ]
+      }
+      set = described_class.new(jwks)
+      expect(set.size).to eql(0)
+    end
+
+    it 'raises on malformed keys with a known kty' do
+      jwks = {
+        keys: [
+          { kty: 'RSA' }
+        ]
+      }
+      expect { described_class.new(jwks) }.to raise_error(JWT::JWKError, /Key format is invalid for RSA/)
+    end
+
     it 'raises an error on invalid inputs' do
       expect { described_class.new(42) }.to raise_error(ArgumentError)
     end


### PR DESCRIPTION
According to RFC7517, unknown algorithms in JWKS should be ignored.

Adherence to this property allow for algorithm upgrade and rotation, and notably is leveraged by existing draft RFC for hybrid PQC. Wherein, a classical algorithm such as RS256 may be used, in addition to the new AKP-type algorithm. All known algorithms must be verified, but all unknown algorithms may be skipped, per RFC7517.

I have tested popular libraries and ruby-jwt is an outlier in its behavior:

| Library | Language | Behavior with unknown kty: "AKP" in JWKS | Result |
|---|---|---|---|
| jose v5.10 | Node.js | Skips unknown key, matches kid to RSA key | PASS |
| PyJWT v2.13 | Python | PyJWKClient filters unknown keys, proceeds | PASS |
 | nimbus-jose-jwt | Java (Spring) | Silently ignores unsupported keys | PASS |
 | go-jose | Go | Returns ErrUnsupportedKeyType per-key, skips it | PASS |
 | ruby-jwt | Ruby | Throws JWT::JWKError: Key type AKP not supported | FAIL |

This change causes ruby-jwt to ignore unknown key types, and enables it to verify keys from signers who have adopted PQC type algorithms such as AKP as part of a hybrid scheme.

### Description

This Pull Request changes/fixes this thing

### Checklist

Before the PR can be merged be sure the following are checked:

- [x] There are tests for the fix or feature added/changed
- [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
