### PR TITLE
Add step to install dependencies in release workflow

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           bundler-cache: false
           ruby-version: ruby
+      - name: Install dependencies
+        run: bundle install
       - name: Release
         run: bundle exec rake release
       - name: Wait for release to propagate


### PR DESCRIPTION
### Description

Sorry, I made a mistake in the previous PR because I had assumed that `bundler-cache: false` would still install dependencies. 

Apparently, it does not. So we have to install them explicitly (while continuing to not do caching, to protect against cache poisoning).

### Checklist

Before the PR can be merged be sure the following are checked:

- [x] There are tests for the fix or feature added/changed
- [x] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)
