### PR TITLE
use proper order of 2 when generating RSA

### DIFF
--- a/spec/jwt/jwa/ps_spec.rb
+++ b/spec/jwt/jwa/ps_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe JWT::JWA::Ps do
     end
 
     context 'with a key length less than 2048 bits' do
-      let(:rsa_key) { OpenSSL::PKey::RSA.generate(2047) }
+      let(:rsa_key) { OpenSSL::PKey::RSA.generate(1536) }
 
       it 'raises an error' do
         expect do

--- a/spec/jwt/jwa/rsa_spec.rb
+++ b/spec/jwt/jwa/rsa_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe JWT::JWA::Rsa do
     end
 
     context 'with a key length less than 2048 bits' do
-      let(:rsa_key) { OpenSSL::PKey::RSA.generate(2047) }
+      let(:rsa_key) { OpenSSL::PKey::RSA.generate(1024) }
 
       it 'raises an error' do
         expect do


### PR DESCRIPTION
### Description

only test changes to be able to run the specs on JRuby.

with Java crypto providers generating primes with sizes that aren't *aligned* isn't really supported

### Checklist

Before the PR can be merged be sure the following are checked:

- [x] There are tests for the fix or feature added/changed
- [ ] A description of the changes and a reference to the PR has been added to CHANGELOG.md. More details in the [CONTRIBUTING.md](https://github.com/jwt/ruby-jwt/blob/main/CONTRIBUTING.md)

skipping `CHANGELOG.md` I don't think this needs to be highlighted in release notes, please let me know otherwise