### PR TITLE
Raise JWT::DecodeError for a malformed x5c header

### DIFF
--- a/lib/jwt/x5c_key_finder.rb
+++ b/lib/jwt/x5c_key_finder.rb
@@ -40,13 +40,21 @@ module JWT
     end
 
     def parse_certificates(x5c_header_or_certificates)
+      unless x5c_header_or_certificates.is_a?(Array) && !x5c_header_or_certificates.empty?
+        raise JWT::DecodeError, 'Invalid x5c header parameter'
+      end
+
       if x5c_header_or_certificates.all?(OpenSSL::X509::Certificate)
         x5c_header_or_certificates
-      else
+      elsif x5c_header_or_certificates.all?(String)
         x5c_header_or_certificates.map do |encoded|
           OpenSSL::X509::Certificate.new(::JWT::Base64.url_decode(encoded))
         end
+      else
+        raise JWT::DecodeError, 'Invalid x5c header parameter'
       end
+    rescue OpenSSL::X509::CertificateError => e
+      raise JWT::DecodeError, "Invalid x5c certificate: #{e.message}"
     end
   end
 end

--- a/spec/jwt/x5c_key_finder_spec.rb
+++ b/spec/jwt/x5c_key_finder_spec.rb
@@ -197,4 +197,18 @@ RSpec.describe JWT::X5cKeyFinder do
     revoked.add_extension(ext)
     revoked
   end
+  context 'when the x5c header parameter is malformed' do
+    [
+      ['a non-array string', 'not-an-array'],
+      ['an integer', 123],
+      ['nil', nil],
+      ['an empty array', []],
+      ['an array of non-string/non-certificate values', [123]],
+      ['an array of valid base64 that is not a certificate', [Base64.strict_encode64('this is not a certificate')]]
+    ].each do |desc, bad_x5c|
+      it "raises JWT::DecodeError for #{desc} rather than a raw exception" do
+        expect { described_class.new([root_certificate], [crl]).from(bad_x5c) }.to raise_error(JWT::DecodeError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `x5c` verification path takes the header value straight off the token and hands it to `parse_certificates`, which calls `.all?` on it and maps every element through `OpenSSL::X509::Certificate.new`. When the header isn't the array of base64 strings the code assumes, the caller gets a raw exception instead of a `JWT::DecodeError`:

- a bare string, a number, or `nil` raises `NoMethodError` (the value has no `.all?`)
- an empty array, or an array holding a non-certificate, raises `OpenSSL::X509::CertificateError`

Both escape before any signature check runs, so code that rescues `JWT::DecodeError` for bad token input (which is the `JWT.decode` contract) sees an unexpected error type instead. `key_finder.rb` already guards the `kid` header this same way, so this just brings `x5c` in line with it.

The patch validates that the value is a non-empty array of strings or certificates and turns an OpenSSL parse failure into `JWT::DecodeError`. The added specs drive the real `from()` path with each malformed shape and assert `JWT::DecodeError`.

`bundle exec rspec spec/jwt/x5c_key_finder_spec.rb` is green. (Two ECDSA specs fail on my local OpenSSL build before and after this change, so they're unrelated.)
