### PR TITLE
Ignore unsupported kty when a Set is built from an array (RFC 7517 §5)

### DIFF
--- a/lib/jwt/jwk/set.rb
+++ b/lib/jwt/jwk/set.rb
@@ -28,7 +28,11 @@ module JWT
                     nil
                   end
                 when Array
-                  jwks.map { |k| JWT::JWK.new(k, nil, options) }
+                  jwks.each_with_object([]) do |k, arr|
+                    arr << JWT::JWK.new(k, nil, options)
+                  rescue JWT::UnsupportedKeyType
+                    nil
+                  end
                 else
                   raise ArgumentError, 'Can only create new JWKS from Hash, Array and JWK'
                 end

--- a/spec/jwt/jwk/set_spec.rb
+++ b/spec/jwt/jwk/set_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe JWT::JWK::Set do
       expect(set.keys[0][:kty]).to eql('oct')
     end
 
+    it 'ignores keys with unsupported kty values when constructed from an array (RFC 7517 §5)' do
+      keys = [
+        { kty: 'unknown', alg: 'unknown-alg', kid: 'unknown' },
+        { kty: 'oct', k: Base64.strict_encode64('testkey') }
+      ]
+      set = described_class.new(keys)
+      expect(set.size).to eql(1)
+      expect(set.keys[0][:kty]).to eql('oct')
+    end
+
     it 'returns an empty set when all keys have unsupported kty values' do
       jwks = {
         keys: [


### PR DESCRIPTION
### What

Makes `JWT::JWK::Set.new(array_of_keys)` skip a key whose `kty` it does not recognise, instead of raising `JWT::UnsupportedKeyType` and failing the whole set.

### Why

The Hash constructor already does this (added in #728, *"Ignore unknown algorithm jwks per RFC 7517"*), but the `Array` branch of `Set#initialize` still did `jwks.map { |k| JWT::JWK.new(...) }` with no rescue, so building a set from a bare array of JWKs remained fatal on one unrecognised key.

RFC 7517 §5 says a processor SHOULD ignore key types it does not understand. This is becoming a live issue as post-quantum keys (ML-DSA, `kty:"AKP"`, RFC 9964) start appearing in published key sets: one unknown key otherwise stops the classical keys next to it from working. Relates to #743. (Note: the Hash path is already fine on `main` thanks to #728; this closes the array-input gap.)

### Change

- `Set#initialize` Array branch now uses the same `each_with_object` + `rescue JWT::UnsupportedKeyType` pattern as the Hash branch.
- Added a spec mirroring the existing Hash-case test.

`spec/jwt/jwk/set_spec.rb` passes (20 examples, 0 failures).